### PR TITLE
Partial revert to maintain QSPI compatability

### DIFF
--- a/Adafruit_SPIFlash.cpp
+++ b/Adafruit_SPIFlash.cpp
@@ -720,7 +720,7 @@ uint32_t Adafruit_SPIFlash::WritePage (uint32_t address, const uint8_t *buffer, 
                 address and size of the flash device.
 */
 /**************************************************************************/
-uint32_t Adafruit_SPIFlash::writeBuffer(uint32_t address, const uint8_t *buffer, uint32_t len)
+uint32_t Adafruit_SPIFlash::writeBuffer(uint32_t address, uint8_t *buffer, uint32_t len)
 {
   uint32_t bytestowrite;
   uint32_t bufferoffset;

--- a/Adafruit_SPIFlash.h
+++ b/Adafruit_SPIFlash.h
@@ -120,7 +120,7 @@ class Adafruit_SPIFlash  : public Print {
   uint32_t WritePage (uint32_t address, const uint8_t *buffer, uint32_t len, bool fastquit=false);
 
   // Write an arbitrary-sized buffer
-  uint32_t writeBuffer (uint32_t address, const uint8_t *buffer, uint32_t len);
+  virtual uint32_t writeBuffer (uint32_t address, uint8_t *buffer, uint32_t len);
   uint32_t findFirstEmptyAddr(void);
   void seek(uint32_t);
   size_t write(uint8_t b);

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit SPIFlash
-version=1.1.0
+version=1.2.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=SPI Flash filesystem support for FAT and CircuitPython FS support from within Arduino


### PR DESCRIPTION
I tested on a Metro M4 with two SPI examples and three QSPI examples plus my own test program.

I also bumped version number to 1.2.0.  If this is not what it should be hopefully you can fix at merge time.