### PR TITLE
fix potential issue with flash cache read

### DIFF
--- a/src/Adafruit_FlashCache.cpp
+++ b/src/Adafruit_FlashCache.cpp
@@ -95,8 +95,8 @@ bool Adafruit_FlashCache::read(Adafruit_SPIFlash* fl, uint32_t addr, uint8_t* bu
        !(addr < cache_addr && addr + count <= cache_addr) &&
        !(addr >= cache_addr + FLASH_CACHE_SIZE) )
   {
-    uint32_t dst_off = cache_addr - addr;
-    uint32_t src_off = 0;
+    int32_t dst_off = cache_addr - addr;
+    int32_t src_off = 0;
 
     if ( dst_off < 0 )
     {
@@ -104,7 +104,7 @@ bool Adafruit_FlashCache::read(Adafruit_SPIFlash* fl, uint32_t addr, uint8_t* bu
       dst_off = 0;
     }
 
-    int cache_bytes = min(FLASH_CACHE_SIZE-src_off, count - dst_off);
+    int32_t cache_bytes = min((int32_t) (FLASH_CACHE_SIZE-src_off), (int32_t) (count - dst_off));
 
     // start to cached
     if ( dst_off ) fl->readBuffer(addr, buffer, dst_off);


### PR DESCRIPTION
`dst_off` & `src_off` can actually be negative. This PR should better fix potential issue with flash cache read. 

follow up from
https://github.com/adafruit/Adafruit_SPIFlash/commit/9fe65a0f42f85f560d4c38dcf9eab88e0c1d5e41#r34518672