### PR TITLE
Fixed for CPX

### DIFF
--- a/examples/SdFat_OpenNext/SdFat_OpenNext.ino
+++ b/examples/SdFat_OpenNext/SdFat_OpenNext.ino
@@ -8,7 +8,7 @@
 #if defined(__SAMD51__) || defined(NRF52840_XXAA)
   Adafruit_FlashTransport_QSPI flashTransport(PIN_QSPI_SCK, PIN_QSPI_CS, PIN_QSPI_IO0, PIN_QSPI_IO1, PIN_QSPI_IO2, PIN_QSPI_IO3);
 #else
-  #if (SPI_INTERFACES_COUNT == 1)
+  #if (SPI_INTERFACES_COUNT == 1 || defined(ADAFRUIT_CIRCUITPLAYGROUND_M0))
     Adafruit_FlashTransport_SPI flashTransport(SS, &SPI);
   #else
     Adafruit_FlashTransport_SPI flashTransport(SS1, &SPI1);

--- a/examples/SdFat_ReadWrite/SdFat_ReadWrite.ino
+++ b/examples/SdFat_ReadWrite/SdFat_ReadWrite.ino
@@ -24,7 +24,7 @@
 #if defined(__SAMD51__) || defined(NRF52840_XXAA)
   Adafruit_FlashTransport_QSPI flashTransport(PIN_QSPI_SCK, PIN_QSPI_CS, PIN_QSPI_IO0, PIN_QSPI_IO1, PIN_QSPI_IO2, PIN_QSPI_IO3);
 #else
-  #if (SPI_INTERFACES_COUNT == 1)
+  #if (SPI_INTERFACES_COUNT == 1 || defined(ADAFRUIT_CIRCUITPLAYGROUND_M0))
     Adafruit_FlashTransport_SPI flashTransport(SS, &SPI);
   #else
     Adafruit_FlashTransport_SPI flashTransport(SS1, &SPI1);

--- a/examples/SdFat_circuitpython/SdFat_circuitpython.ino
+++ b/examples/SdFat_circuitpython/SdFat_circuitpython.ino
@@ -33,7 +33,7 @@
 #if defined(__SAMD51__) || defined(NRF52840_XXAA)
   Adafruit_FlashTransport_QSPI flashTransport(PIN_QSPI_SCK, PIN_QSPI_CS, PIN_QSPI_IO0, PIN_QSPI_IO1, PIN_QSPI_IO2, PIN_QSPI_IO3);
 #else
-  #if (SPI_INTERFACES_COUNT == 1)
+  #if (SPI_INTERFACES_COUNT == 1 || defined(ADAFRUIT_CIRCUITPLAYGROUND_M0))
     Adafruit_FlashTransport_SPI flashTransport(SS, &SPI);
   #else
     Adafruit_FlashTransport_SPI flashTransport(SS1, &SPI1);

--- a/examples/SdFat_datalogging/SdFat_datalogging.ino
+++ b/examples/SdFat_datalogging/SdFat_datalogging.ino
@@ -25,7 +25,7 @@
 #if defined(__SAMD51__) || defined(NRF52840_XXAA)
   Adafruit_FlashTransport_QSPI flashTransport(PIN_QSPI_SCK, PIN_QSPI_CS, PIN_QSPI_IO0, PIN_QSPI_IO1, PIN_QSPI_IO2, PIN_QSPI_IO3);
 #else
-  #if (SPI_INTERFACES_COUNT == 1)
+  #if (SPI_INTERFACES_COUNT == 1 || defined(ADAFRUIT_CIRCUITPLAYGROUND_M0))
     Adafruit_FlashTransport_SPI flashTransport(SS, &SPI);
   #else
     Adafruit_FlashTransport_SPI flashTransport(SS1, &SPI1);

--- a/examples/SdFat_format/SdFat_format.ino
+++ b/examples/SdFat_format/SdFat_format.ino
@@ -30,7 +30,7 @@
 #if defined(__SAMD51__) || defined(NRF52840_XXAA)
   Adafruit_FlashTransport_QSPI flashTransport(PIN_QSPI_SCK, PIN_QSPI_CS, PIN_QSPI_IO0, PIN_QSPI_IO1, PIN_QSPI_IO2, PIN_QSPI_IO3);
 #else
-  #if (SPI_INTERFACES_COUNT == 1)
+  #if (SPI_INTERFACES_COUNT == 1 || defined(ADAFRUIT_CIRCUITPLAYGROUND_M0))
     Adafruit_FlashTransport_SPI flashTransport(SS, &SPI);
   #else
     Adafruit_FlashTransport_SPI flashTransport(SS1, &SPI1);

--- a/examples/SdFat_full_usage/SdFat_full_usage.ino
+++ b/examples/SdFat_full_usage/SdFat_full_usage.ino
@@ -33,7 +33,7 @@
 #if defined(__SAMD51__) || defined(NRF52840_XXAA)
   Adafruit_FlashTransport_QSPI flashTransport(PIN_QSPI_SCK, PIN_QSPI_CS, PIN_QSPI_IO0, PIN_QSPI_IO1, PIN_QSPI_IO2, PIN_QSPI_IO3);
 #else
-  #if (SPI_INTERFACES_COUNT == 1)
+  #if (SPI_INTERFACES_COUNT == 1 || defined(ADAFRUIT_CIRCUITPLAYGROUND_M0))
     Adafruit_FlashTransport_SPI flashTransport(SS, &SPI);
   #else
     Adafruit_FlashTransport_SPI flashTransport(SS1, &SPI1);

--- a/examples/SdFat_print_file/SdFat_print_file.ino
+++ b/examples/SdFat_print_file/SdFat_print_file.ino
@@ -26,7 +26,7 @@
 #if defined(__SAMD51__) || defined(NRF52840_XXAA)
   Adafruit_FlashTransport_QSPI flashTransport(PIN_QSPI_SCK, PIN_QSPI_CS, PIN_QSPI_IO0, PIN_QSPI_IO1, PIN_QSPI_IO2, PIN_QSPI_IO3);
 #else
-  #if (SPI_INTERFACES_COUNT == 1)
+  #if (SPI_INTERFACES_COUNT == 1 || defined(ADAFRUIT_CIRCUITPLAYGROUND_M0))
     Adafruit_FlashTransport_SPI flashTransport(SS, &SPI);
   #else
     Adafruit_FlashTransport_SPI flashTransport(SS1, &SPI1);

--- a/examples/circuitpython_backupFiles/circuitpython_backupFiles.ino
+++ b/examples/circuitpython_backupFiles/circuitpython_backupFiles.ino
@@ -22,7 +22,7 @@
 #if defined(__SAMD51__) || defined(NRF52840_XXAA)
   Adafruit_FlashTransport_QSPI flashTransport(PIN_QSPI_SCK, PIN_QSPI_CS, PIN_QSPI_IO0, PIN_QSPI_IO1, PIN_QSPI_IO2, PIN_QSPI_IO3);
 #else
-  #if (SPI_INTERFACES_COUNT == 1)
+  #if (SPI_INTERFACES_COUNT == 1 || defined(ADAFRUIT_CIRCUITPLAYGROUND_M0))
     Adafruit_FlashTransport_SPI flashTransport(SS, &SPI);
   #else
     Adafruit_FlashTransport_SPI flashTransport(SS1, &SPI1);

--- a/examples/flash_erase/flash_erase.ino
+++ b/examples/flash_erase/flash_erase.ino
@@ -30,7 +30,7 @@
 #if defined(__SAMD51__) || defined(NRF52840_XXAA)
   Adafruit_FlashTransport_QSPI flashTransport(PIN_QSPI_SCK, PIN_QSPI_CS, PIN_QSPI_IO0, PIN_QSPI_IO1, PIN_QSPI_IO2, PIN_QSPI_IO3);
 #else
-  #if (SPI_INTERFACES_COUNT == 1)
+  #if (SPI_INTERFACES_COUNT == 1 || defined(ADAFRUIT_CIRCUITPLAYGROUND_M0))
     Adafruit_FlashTransport_SPI flashTransport(SS, &SPI);
   #else
     Adafruit_FlashTransport_SPI flashTransport(SS1, &SPI1);

--- a/examples/flash_erase_express/flash_erase_express.ino
+++ b/examples/flash_erase_express/flash_erase_express.ino
@@ -32,7 +32,7 @@
 #if defined(__SAMD51__) || defined(NRF52840_XXAA)
   Adafruit_FlashTransport_QSPI flashTransport(PIN_QSPI_SCK, PIN_QSPI_CS, PIN_QSPI_IO0, PIN_QSPI_IO1, PIN_QSPI_IO2, PIN_QSPI_IO3);
 #else
-  #if (SPI_INTERFACES_COUNT == 1)
+  #if (SPI_INTERFACES_COUNT == 1 || defined(ADAFRUIT_CIRCUITPLAYGROUND_M0))
     Adafruit_FlashTransport_SPI flashTransport(SS, &SPI);
   #else
     Adafruit_FlashTransport_SPI flashTransport(SS1, &SPI1);

--- a/examples/flash_info/flash_info.ino
+++ b/examples/flash_info/flash_info.ino
@@ -7,7 +7,7 @@
 #if defined(__SAMD51__) || defined(NRF52840_XXAA)
   Adafruit_FlashTransport_QSPI flashTransport(PIN_QSPI_SCK, PIN_QSPI_CS, PIN_QSPI_IO0, PIN_QSPI_IO1, PIN_QSPI_IO2, PIN_QSPI_IO3);
 #else
-  #if (SPI_INTERFACES_COUNT == 1)
+  #if (SPI_INTERFACES_COUNT == 1 || defined(ADAFRUIT_CIRCUITPLAYGROUND_M0))
     Adafruit_FlashTransport_SPI flashTransport(SS, &SPI);
   #else
     Adafruit_FlashTransport_SPI flashTransport(SS1, &SPI1);

--- a/examples/flash_manipulator/flash_manipulator.ino
+++ b/examples/flash_manipulator/flash_manipulator.ino
@@ -6,7 +6,7 @@
 #if defined(__SAMD51__) || defined(NRF52840_XXAA)
   Adafruit_FlashTransport_QSPI flashTransport(PIN_QSPI_SCK, PIN_QSPI_CS, PIN_QSPI_IO0, PIN_QSPI_IO1, PIN_QSPI_IO2, PIN_QSPI_IO3);
 #else
-  #if (SPI_INTERFACES_COUNT == 1)
+  #if (SPI_INTERFACES_COUNT == 1 || defined(ADAFRUIT_CIRCUITPLAYGROUND_M0))
     Adafruit_FlashTransport_SPI flashTransport(SS, &SPI);
   #else
     Adafruit_FlashTransport_SPI flashTransport(SS1, &SPI1);

--- a/examples/flash_sector_dump/flash_sector_dump.ino
+++ b/examples/flash_sector_dump/flash_sector_dump.ino
@@ -7,7 +7,7 @@
 #if defined(__SAMD51__) || defined(NRF52840_XXAA)
   Adafruit_FlashTransport_QSPI flashTransport(PIN_QSPI_SCK, PIN_QSPI_CS, PIN_QSPI_IO0, PIN_QSPI_IO1, PIN_QSPI_IO2, PIN_QSPI_IO3);
 #else
-  #if (SPI_INTERFACES_COUNT == 1)
+  #if (SPI_INTERFACES_COUNT == 1 || defined(ADAFRUIT_CIRCUITPLAYGROUND_M0))
     Adafruit_FlashTransport_SPI flashTransport(SS, &SPI);
   #else
     Adafruit_FlashTransport_SPI flashTransport(SS1, &SPI1);


### PR DESCRIPTION
Resolves the issue of it not working on the CPX since it has > 1 SPI interface, but uses SPI for flash.
Fixes #26.