### PR TITLE
Provide Empty Adafruit_SPIFlash Constructor

### DIFF
--- a/src/Adafruit_SPIFlash.cpp
+++ b/src/Adafruit_SPIFlash.cpp
@@ -47,6 +47,8 @@ Adafruit_SPIFlash::Adafruit_SPIFlash(Adafruit_FlashTransport* transport)
 
 bool Adafruit_SPIFlash::begin(void)
 {
+  if (_trans == NULL) return false;
+
   _trans->begin();
 
   //------------- flash detection -------------//

--- a/src/Adafruit_SPIFlash.cpp
+++ b/src/Adafruit_SPIFlash.cpp
@@ -31,6 +31,12 @@ enum
   EXTERNAL_FLASH_DEVICE_COUNT = sizeof(possible_devices)/sizeof(possible_devices[0])
 };
 
+Adafruit_SPIFlash::Adafruit_SPIFlash()
+  : _cache()
+{
+  _trans = NULL;
+  _flash_dev = NULL;
+}
 
 Adafruit_SPIFlash::Adafruit_SPIFlash(Adafruit_FlashTransport* transport)
   : _cache()

--- a/src/Adafruit_SPIFlash.h
+++ b/src/Adafruit_SPIFlash.h
@@ -80,6 +80,7 @@ enum {
 class Adafruit_SPIFlash : public BaseBlockDriver
 {
 public:
+	Adafruit_SPIFlash();
 	Adafruit_SPIFlash(Adafruit_FlashTransport* transport);
 	~Adafruit_SPIFlash() {}
 


### PR DESCRIPTION
Provide an empty Adafruit_SPIFlash constructor to allow object declaration at compile time and to later create the object in another library or at runtime specifying a created Adafruit_FlashTransport_QSPI object.

Tested with Adafruit Feather M4 Express and a local convenience flash library that instantiates the Adafruit_SPIFlash object using an Adafruit_FlashTransport_QSPI object.