### PR TITLE
Use new Flash Defines in variant

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arduino-platform: ['metro_m0', 'metro_m4', 'nrf52840', 'cpx', 'cpb']
+        arduino-platform: ['metro_m0', 'metro_m4', 'nrf52840', 'cpx_ada', 'cpb']
 
     runs-on: ubuntu-latest
     steps:

--- a/examples/SdFat_OpenNext/SdFat_OpenNext.ino
+++ b/examples/SdFat_OpenNext/SdFat_OpenNext.ino
@@ -5,14 +5,18 @@
 #include "SdFat.h"
 #include "Adafruit_SPIFlash.h"
 
-#if defined(__SAMD51__) || defined(NRF52840_XXAA)
-  Adafruit_FlashTransport_QSPI flashTransport(PIN_QSPI_SCK, PIN_QSPI_CS, PIN_QSPI_IO0, PIN_QSPI_IO1, PIN_QSPI_IO2, PIN_QSPI_IO3);
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+  Adafruit_FlashTransport_QSPI flashTransport;
+
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
 #else
-  #if (SPI_INTERFACES_COUNT == 1 || defined(ADAFRUIT_CIRCUITPLAYGROUND_M0))
-    Adafruit_FlashTransport_SPI flashTransport(SS, &SPI);
-  #else
-    Adafruit_FlashTransport_SPI flashTransport(SS1, &SPI1);
-  #endif
+  #error No QSPI/SPI flash are defined on your board variant.h !
 #endif
 
 Adafruit_SPIFlash flash(&flashTransport);

--- a/examples/SdFat_ReadWrite/SdFat_ReadWrite.ino
+++ b/examples/SdFat_ReadWrite/SdFat_ReadWrite.ino
@@ -21,14 +21,18 @@
 #include "SdFat.h"
 #include "Adafruit_SPIFlash.h"
 
-#if defined(__SAMD51__) || defined(NRF52840_XXAA)
-  Adafruit_FlashTransport_QSPI flashTransport(PIN_QSPI_SCK, PIN_QSPI_CS, PIN_QSPI_IO0, PIN_QSPI_IO1, PIN_QSPI_IO2, PIN_QSPI_IO3);
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+  Adafruit_FlashTransport_QSPI flashTransport;
+
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
 #else
-  #if (SPI_INTERFACES_COUNT == 1 || defined(ADAFRUIT_CIRCUITPLAYGROUND_M0))
-    Adafruit_FlashTransport_SPI flashTransport(SS, &SPI);
-  #else
-    Adafruit_FlashTransport_SPI flashTransport(SS1, &SPI1);
-  #endif
+  #error No QSPI/SPI flash are defined on your board variant.h !
 #endif
 
 Adafruit_SPIFlash flash(&flashTransport);

--- a/examples/SdFat_circuitpython/SdFat_circuitpython.ino
+++ b/examples/SdFat_circuitpython/SdFat_circuitpython.ino
@@ -27,17 +27,18 @@
 #include <SdFat.h>
 #include <Adafruit_SPIFlash.h>
 
-// Configuration of the flash chip pins and flash fatfs object.
-// You don't normally need to change these if using a Feather/Metro
-// M0 express board.
-#if defined(__SAMD51__) || defined(NRF52840_XXAA)
-  Adafruit_FlashTransport_QSPI flashTransport(PIN_QSPI_SCK, PIN_QSPI_CS, PIN_QSPI_IO0, PIN_QSPI_IO1, PIN_QSPI_IO2, PIN_QSPI_IO3);
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+  Adafruit_FlashTransport_QSPI flashTransport;
+
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
 #else
-  #if (SPI_INTERFACES_COUNT == 1 || defined(ADAFRUIT_CIRCUITPLAYGROUND_M0))
-    Adafruit_FlashTransport_SPI flashTransport(SS, &SPI);
-  #else
-    Adafruit_FlashTransport_SPI flashTransport(SS1, &SPI1);
-  #endif
+  #error No QSPI/SPI flash are defined on your board variant.h !
 #endif
 
 Adafruit_SPIFlash flash(&flashTransport);

--- a/examples/SdFat_datalogging/SdFat_datalogging.ino
+++ b/examples/SdFat_datalogging/SdFat_datalogging.ino
@@ -19,17 +19,18 @@
 #include <SdFat.h>
 #include <Adafruit_SPIFlash.h>
 
-// Configuration of the flash chip pins and flash fatfs object.
-// You don't normally need to change these if using a Feather/Metro
-// M0 express board.
-#if defined(__SAMD51__) || defined(NRF52840_XXAA)
-  Adafruit_FlashTransport_QSPI flashTransport(PIN_QSPI_SCK, PIN_QSPI_CS, PIN_QSPI_IO0, PIN_QSPI_IO1, PIN_QSPI_IO2, PIN_QSPI_IO3);
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+  Adafruit_FlashTransport_QSPI flashTransport;
+
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
 #else
-  #if (SPI_INTERFACES_COUNT == 1 || defined(ADAFRUIT_CIRCUITPLAYGROUND_M0))
-    Adafruit_FlashTransport_SPI flashTransport(SS, &SPI);
-  #else
-    Adafruit_FlashTransport_SPI flashTransport(SS1, &SPI1);
-  #endif
+  #error No QSPI/SPI flash are defined on your board variant.h !
 #endif
 
 Adafruit_SPIFlash flash(&flashTransport);

--- a/examples/SdFat_format/SdFat_format.ino
+++ b/examples/SdFat_format/SdFat_format.ino
@@ -27,14 +27,18 @@
 #include "ff.h"
 #include "diskio.h"
 
-#if defined(__SAMD51__) || defined(NRF52840_XXAA)
-  Adafruit_FlashTransport_QSPI flashTransport(PIN_QSPI_SCK, PIN_QSPI_CS, PIN_QSPI_IO0, PIN_QSPI_IO1, PIN_QSPI_IO2, PIN_QSPI_IO3);
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+  Adafruit_FlashTransport_QSPI flashTransport;
+
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
 #else
-  #if (SPI_INTERFACES_COUNT == 1 || defined(ADAFRUIT_CIRCUITPLAYGROUND_M0))
-    Adafruit_FlashTransport_SPI flashTransport(SS, &SPI);
-  #else
-    Adafruit_FlashTransport_SPI flashTransport(SS1, &SPI1);
-  #endif
+  #error No QSPI/SPI flash are defined on your board variant.h !
 #endif
 
 Adafruit_SPIFlash flash(&flashTransport);

--- a/examples/SdFat_full_usage/SdFat_full_usage.ino
+++ b/examples/SdFat_full_usage/SdFat_full_usage.ino
@@ -26,18 +26,18 @@
 #include <SdFat.h>
 #include <Adafruit_SPIFlash.h>
 
-// Configuration of the flash chip pins and flash fatfs object.
-// You don't normally need to change these if using a Feather/Metro
-// M0 express board.
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+  Adafruit_FlashTransport_QSPI flashTransport;
 
-#if defined(__SAMD51__) || defined(NRF52840_XXAA)
-  Adafruit_FlashTransport_QSPI flashTransport(PIN_QSPI_SCK, PIN_QSPI_CS, PIN_QSPI_IO0, PIN_QSPI_IO1, PIN_QSPI_IO2, PIN_QSPI_IO3);
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
 #else
-  #if (SPI_INTERFACES_COUNT == 1 || defined(ADAFRUIT_CIRCUITPLAYGROUND_M0))
-    Adafruit_FlashTransport_SPI flashTransport(SS, &SPI);
-  #else
-    Adafruit_FlashTransport_SPI flashTransport(SS1, &SPI1);
-  #endif
+  #error No QSPI/SPI flash are defined on your board variant.h !
 #endif
 
 Adafruit_SPIFlash flash(&flashTransport);

--- a/examples/SdFat_print_file/SdFat_print_file.ino
+++ b/examples/SdFat_print_file/SdFat_print_file.ino
@@ -23,14 +23,18 @@
 #include <SdFat.h>
 #include <Adafruit_SPIFlash.h>
 
-#if defined(__SAMD51__) || defined(NRF52840_XXAA)
-  Adafruit_FlashTransport_QSPI flashTransport(PIN_QSPI_SCK, PIN_QSPI_CS, PIN_QSPI_IO0, PIN_QSPI_IO1, PIN_QSPI_IO2, PIN_QSPI_IO3);
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+  Adafruit_FlashTransport_QSPI flashTransport;
+
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
 #else
-  #if (SPI_INTERFACES_COUNT == 1 || defined(ADAFRUIT_CIRCUITPLAYGROUND_M0))
-    Adafruit_FlashTransport_SPI flashTransport(SS, &SPI);
-  #else
-    Adafruit_FlashTransport_SPI flashTransport(SS1, &SPI1);
-  #endif
+  #error No QSPI/SPI flash are defined on your board variant.h !
 #endif
 
 Adafruit_SPIFlash flash(&flashTransport);

--- a/examples/circuitpython_backupFiles/circuitpython_backupFiles.ino
+++ b/examples/circuitpython_backupFiles/circuitpython_backupFiles.ino
@@ -16,17 +16,18 @@
 #include <Adafruit_SPIFlash.h>
 #include <Adafruit_NeoPixel.h>
 
-// Configuration of the flash chip pins and flash fatfs object.
-// You don't normally need to change these if using a Feather/Metro
-// M0 express board.
-#if defined(__SAMD51__) || defined(NRF52840_XXAA)
-  Adafruit_FlashTransport_QSPI flashTransport(PIN_QSPI_SCK, PIN_QSPI_CS, PIN_QSPI_IO0, PIN_QSPI_IO1, PIN_QSPI_IO2, PIN_QSPI_IO3);
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+  Adafruit_FlashTransport_QSPI flashTransport;
+
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
 #else
-  #if (SPI_INTERFACES_COUNT == 1 || defined(ADAFRUIT_CIRCUITPLAYGROUND_M0))
-    Adafruit_FlashTransport_SPI flashTransport(SS, &SPI);
-  #else
-    Adafruit_FlashTransport_SPI flashTransport(SS1, &SPI1);
-  #endif
+  #error No QSPI/SPI flash are defined on your board variant.h !
 #endif
 
 Adafruit_SPIFlash flash(&flashTransport);

--- a/examples/flash_erase/flash_erase.ino
+++ b/examples/flash_erase/flash_erase.ino
@@ -23,18 +23,18 @@
 #include <SdFat.h>
 #include <Adafruit_SPIFlash.h>
 
-// Configuration of the flash chip pins and flash fatfs object.
-// You don't normally need to change these if using a Feather/Metro
-// M0 express board.
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+  Adafruit_FlashTransport_QSPI flashTransport;
 
-#if defined(__SAMD51__) || defined(NRF52840_XXAA)
-  Adafruit_FlashTransport_QSPI flashTransport(PIN_QSPI_SCK, PIN_QSPI_CS, PIN_QSPI_IO0, PIN_QSPI_IO1, PIN_QSPI_IO2, PIN_QSPI_IO3);
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
 #else
-  #if (SPI_INTERFACES_COUNT == 1 || defined(ADAFRUIT_CIRCUITPLAYGROUND_M0))
-    Adafruit_FlashTransport_SPI flashTransport(SS, &SPI);
-  #else
-    Adafruit_FlashTransport_SPI flashTransport(SS1, &SPI1);
-  #endif
+  #error No QSPI/SPI flash are defined on your board variant.h !
 #endif
 
 Adafruit_SPIFlash flash(&flashTransport);

--- a/examples/flash_erase_express/flash_erase_express.ino
+++ b/examples/flash_erase_express/flash_erase_express.ino
@@ -25,18 +25,18 @@
 #include <Adafruit_SPIFlash.h>
 #include <Adafruit_NeoPixel.h>
 
-// Configuration of the flash chip pins and flash fatfs object.
-// You don't normally need to change these if using a Feather/Metro
-// M0 express board.
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+  Adafruit_FlashTransport_QSPI flashTransport;
 
-#if defined(__SAMD51__) || defined(NRF52840_XXAA)
-  Adafruit_FlashTransport_QSPI flashTransport(PIN_QSPI_SCK, PIN_QSPI_CS, PIN_QSPI_IO0, PIN_QSPI_IO1, PIN_QSPI_IO2, PIN_QSPI_IO3);
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
 #else
-  #if (SPI_INTERFACES_COUNT == 1 || defined(ADAFRUIT_CIRCUITPLAYGROUND_M0))
-    Adafruit_FlashTransport_SPI flashTransport(SS, &SPI);
-  #else
-    Adafruit_FlashTransport_SPI flashTransport(SS1, &SPI1);
-  #endif
+  #error No QSPI/SPI flash are defined on your board variant.h !
 #endif
 
 Adafruit_SPIFlash flash(&flashTransport);

--- a/examples/flash_info/flash_info.ino
+++ b/examples/flash_info/flash_info.ino
@@ -4,15 +4,20 @@
 #include "SdFat.h"
 #include "Adafruit_SPIFlash.h"
 
-#if defined(__SAMD51__) || defined(NRF52840_XXAA)
-  Adafruit_FlashTransport_QSPI flashTransport(PIN_QSPI_SCK, PIN_QSPI_CS, PIN_QSPI_IO0, PIN_QSPI_IO1, PIN_QSPI_IO2, PIN_QSPI_IO3);
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+  Adafruit_FlashTransport_QSPI flashTransport;
+
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
 #else
-  #if (SPI_INTERFACES_COUNT == 1 || defined(ADAFRUIT_CIRCUITPLAYGROUND_M0))
-    Adafruit_FlashTransport_SPI flashTransport(SS, &SPI);
-  #else
-    Adafruit_FlashTransport_SPI flashTransport(SS1, &SPI1);
-  #endif
+  #error No QSPI/SPI flash are defined on your board variant.h !
 #endif
+
 
 Adafruit_SPIFlash flash(&flashTransport);
 

--- a/examples/flash_manipulator/flash_manipulator.ino
+++ b/examples/flash_manipulator/flash_manipulator.ino
@@ -3,15 +3,20 @@
 #include <SdFat.h>
 #include <Adafruit_SPIFlash.h>
 
-#if defined(__SAMD51__) || defined(NRF52840_XXAA)
-  Adafruit_FlashTransport_QSPI flashTransport(PIN_QSPI_SCK, PIN_QSPI_CS, PIN_QSPI_IO0, PIN_QSPI_IO1, PIN_QSPI_IO2, PIN_QSPI_IO3);
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+  Adafruit_FlashTransport_QSPI flashTransport;
+
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
 #else
-  #if (SPI_INTERFACES_COUNT == 1 || defined(ADAFRUIT_CIRCUITPLAYGROUND_M0))
-    Adafruit_FlashTransport_SPI flashTransport(SS, &SPI);
-  #else
-    Adafruit_FlashTransport_SPI flashTransport(SS1, &SPI1);
-  #endif
+  #error No QSPI/SPI flash are defined on your board variant.h !
 #endif
+
 
 Adafruit_SPIFlash flash(&flashTransport);
 

--- a/examples/flash_sector_dump/flash_sector_dump.ino
+++ b/examples/flash_sector_dump/flash_sector_dump.ino
@@ -4,14 +4,18 @@
 #include "SdFat.h"
 #include "Adafruit_SPIFlash.h"
 
-#if defined(__SAMD51__) || defined(NRF52840_XXAA)
-  Adafruit_FlashTransport_QSPI flashTransport(PIN_QSPI_SCK, PIN_QSPI_CS, PIN_QSPI_IO0, PIN_QSPI_IO1, PIN_QSPI_IO2, PIN_QSPI_IO3);
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+  Adafruit_FlashTransport_QSPI flashTransport;
+
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
 #else
-  #if (SPI_INTERFACES_COUNT == 1 || defined(ADAFRUIT_CIRCUITPLAYGROUND_M0))
-    Adafruit_FlashTransport_SPI flashTransport(SS, &SPI);
-  #else
-    Adafruit_FlashTransport_SPI flashTransport(SS1, &SPI1);
-  #endif
+  #error No QSPI/SPI flash are defined on your board variant.h !
 #endif
 
 Adafruit_SPIFlash flash(&flashTransport);

--- a/src/spi/Adafruit_FlashTransport_SPI.cpp
+++ b/src/spi/Adafruit_FlashTransport_SPI.cpp
@@ -31,6 +31,12 @@ Adafruit_FlashTransport_SPI::Adafruit_FlashTransport_SPI(
   _setting = SPISettings();
 }
 
+Adafruit_FlashTransport_SPI::Adafruit_FlashTransport_SPI(uint8_t ss, SPIClass& spiinterface)
+  : Adafruit_FlashTransport_SPI(ss, &spiinterface)
+{
+
+}
+
 void Adafruit_FlashTransport_SPI::begin(void) {
   pinMode(_ss, OUTPUT);
   digitalWrite(_ss, HIGH);

--- a/src/spi/Adafruit_FlashTransport_SPI.cpp
+++ b/src/spi/Adafruit_FlashTransport_SPI.cpp
@@ -31,11 +31,9 @@ Adafruit_FlashTransport_SPI::Adafruit_FlashTransport_SPI(
   _setting = SPISettings();
 }
 
-Adafruit_FlashTransport_SPI::Adafruit_FlashTransport_SPI(uint8_t ss, SPIClass& spiinterface)
-  : Adafruit_FlashTransport_SPI(ss, &spiinterface)
-{
-
-}
+Adafruit_FlashTransport_SPI::Adafruit_FlashTransport_SPI(uint8_t ss,
+                                                         SPIClass &spiinterface)
+    : Adafruit_FlashTransport_SPI(ss, &spiinterface) {}
 
 void Adafruit_FlashTransport_SPI::begin(void) {
   pinMode(_ss, OUTPUT);

--- a/src/spi/Adafruit_FlashTransport_SPI.h
+++ b/src/spi/Adafruit_FlashTransport_SPI.h
@@ -35,6 +35,7 @@ private:
 
 public:
   Adafruit_FlashTransport_SPI(uint8_t ss, SPIClass *spiinterface);
+  Adafruit_FlashTransport_SPI(uint8_t ss, SPIClass& spiinterface);
 
   virtual void begin(void);
 

--- a/src/spi/Adafruit_FlashTransport_SPI.h
+++ b/src/spi/Adafruit_FlashTransport_SPI.h
@@ -35,7 +35,7 @@ private:
 
 public:
   Adafruit_FlashTransport_SPI(uint8_t ss, SPIClass *spiinterface);
-  Adafruit_FlashTransport_SPI(uint8_t ss, SPIClass& spiinterface);
+  Adafruit_FlashTransport_SPI(uint8_t ss, SPIClass &spiinterface);
 
   virtual void begin(void);
 


### PR DESCRIPTION
example use EXTERNAL_FLASH_USE_QSPI EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI added by

- https://github.com/adafruit/ArduinoCore-samd/pull/210
- https://github.com/adafruit/Adafruit_nRF52_Arduino/pull/432

NOTE: action failed since it requires both BSP release of SAMD and NRF, we should not merge this until those BSP are released, then re-run this tests.