### PR TITLE
Add ability to provide explicit device in begin()

### DIFF
--- a/src/Adafruit_SPIFlashBase.h
+++ b/src/Adafruit_SPIFlashBase.h
@@ -47,7 +47,7 @@ public:
   Adafruit_SPIFlashBase(Adafruit_FlashTransport *transport);
   ~Adafruit_SPIFlashBase() {}
 
-  bool begin(void);
+  bool begin(external_flash_device *flash_dev = NULL);
   bool end(void);
 
   uint16_t numPages(void);


### PR DESCRIPTION
Resolves #46

Non-breaking change