### PR TITLE
Support a list of devices in begin()

### DIFF
--- a/src/Adafruit_SPIFlashBase.cpp
+++ b/src/Adafruit_SPIFlashBase.cpp
@@ -63,7 +63,7 @@ static SPIFlash_Device_t const *findDevice(SPIFlash_Device_t const *device_list,
   for (uint8_t i = 0; i < count; i++) {
     const SPIFlash_Device_t *dev = &device_list[i];
     if (jedec_ids[0] == dev->manufacturer_id &&
-        jedec_ids[1] == dev->memory_type &&
+        jedec_ids[1] == dev->memory_type && // comment to appease format check
         jedec_ids[2] == dev->capacity) {
       return dev;
     }

--- a/src/Adafruit_SPIFlashBase.cpp
+++ b/src/Adafruit_SPIFlashBase.cpp
@@ -61,18 +61,18 @@ static SPIFlash_Device_t const *findDevice(SPIFlash_Device_t const *device_list,
                                            int count,
                                            uint8_t const (&jedec_ids)[3]) {
   for (uint8_t i = 0; i < count; i++) {
-    const SPIFlash_Device_t *possible_device = &device_list[i];
-    if (jedec_ids[0] == possible_device->manufacturer_id &&
-        jedec_ids[1] == possible_device->memory_type &&
-        jedec_ids[2] == possible_device->capacity) {
-      return possible_device;
+    const SPIFlash_Device_t *dev = &device_list[i];
+    if (jedec_ids[0] == dev->manufacturer_id &&
+        jedec_ids[1] == dev->memory_type &&
+        jedec_ids[2] == dev->capacity) {
+      return dev;
     }
   }
   return NULL;
 }
 
 bool Adafruit_SPIFlashBase::begin(SPIFlash_Device_t const *flash_devs,
-                                  int count) {
+                                  size_t count) {
   if (_trans == NULL)
     return false;
 
@@ -90,11 +90,6 @@ bool Adafruit_SPIFlashBase::begin(SPIFlash_Device_t const *flash_devs,
   if (_flash_dev == NULL) {
     _flash_dev =
         findDevice(possible_devices, EXTERNAL_FLASH_DEVICE_COUNT, jedec_ids);
-  }
-  // If still not found, use the first supplied deivce, if any (backward
-  // compatible behaviour).
-  if (_flash_dev == NULL && flash_devs) {
-    _flash_dev = flash_devs;
   }
 
   if (_flash_dev == NULL)

--- a/src/Adafruit_SPIFlashBase.h
+++ b/src/Adafruit_SPIFlashBase.h
@@ -47,7 +47,7 @@ public:
   Adafruit_SPIFlashBase(Adafruit_FlashTransport *transport);
   ~Adafruit_SPIFlashBase() {}
 
-  bool begin(SPIFlash_Device_t const *flash_devs = NULL, int count = 1);
+  bool begin(SPIFlash_Device_t const *flash_devs = NULL, size_t count = 1);
   bool end(void);
 
   uint16_t numPages(void);

--- a/src/Adafruit_SPIFlashBase.h
+++ b/src/Adafruit_SPIFlashBase.h
@@ -47,7 +47,7 @@ public:
   Adafruit_SPIFlashBase(Adafruit_FlashTransport *transport);
   ~Adafruit_SPIFlashBase() {}
 
-  bool begin(SPIFlash_Device_t const *flash_dev = NULL);
+  bool begin(SPIFlash_Device_t const *flash_devs = NULL, int count = 1);
   bool end(void);
 
   uint16_t numPages(void);


### PR DESCRIPTION
- Adds a count parameter to begin() this is the count of devices pointed to by the first argument.
- Count defaults to 1, so backwards compatible with old API where pointer to one device was passed.
- Behavior change: The JEDEC ids are always fetched and matched, first against the user supplied list
	(if any), and second against the standard list
- Backward compatibility: If the id doesn't match any device, the supplied device (if any) is used anyway.

- Fixes issue #54 