### PR TITLE
Fix compile warning

### DIFF
--- a/src/Adafruit_SPIFlash.cpp
+++ b/src/Adafruit_SPIFlash.cpp
@@ -16,10 +16,10 @@
 #define SPIFLASH_LOG(_sector, _count)
 #endif
 
-Adafruit_SPIFlash::Adafruit_SPIFlash() : _cache(), Adafruit_SPIFlashBase() {}
+Adafruit_SPIFlash::Adafruit_SPIFlash() : Adafruit_SPIFlashBase(), _cache() {}
 
 Adafruit_SPIFlash::Adafruit_SPIFlash(Adafruit_FlashTransport *transport)
-    : _cache(), Adafruit_SPIFlashBase(transport) {}
+    : Adafruit_SPIFlashBase(transport), _cache() {}
 
 //--------------------------------------------------------------------+
 // SdFat BaseBlockDRiver API


### PR DESCRIPTION
This will fix compile warning:
warning: 'Adafruit_SPIFlash::_cache' will be initialized after [-Wreorder] Adafruit_FlashCache _cache;