### PR TITLE
Support FRAM also vastly improve speed using DMA

### DIFF
--- a/examples/SdFat_ReadWrite/SdFat_ReadWrite.ino
+++ b/examples/SdFat_ReadWrite/SdFat_ReadWrite.ino
@@ -21,18 +21,27 @@
 #include "SdFat.h"
 #include "Adafruit_SPIFlash.h"
 
-// On-board external flash (QSPI or SPI) macros should already
-// defined in your board variant if supported
-// - EXTERNAL_FLASH_USE_QSPI
-// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-#if defined(EXTERNAL_FLASH_USE_QSPI)
-  Adafruit_FlashTransport_QSPI flashTransport;
+// Uncomment to run example with FRAM
+// #define FRAM_CS   A5
+// #define FRAM_SPI  SPI
 
-#elif defined(EXTERNAL_FLASH_USE_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+#if defined(FRAM_CS) && defined(FRAM_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(FRAM_CS, FRAM_SPI);
 
 #else
-  #error No QSPI/SPI flash are defined on your board variant.h !
+  // On-board external flash (QSPI or SPI) macros should already
+  // defined in your board variant if supported
+  // - EXTERNAL_FLASH_USE_QSPI
+  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+  #if defined(EXTERNAL_FLASH_USE_QSPI)
+    Adafruit_FlashTransport_QSPI flashTransport;
+
+  #elif defined(EXTERNAL_FLASH_USE_SPI)
+    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
+  #else
+    #error No QSPI/SPI flash are defined on your board variant.h !
+  #endif
 #endif
 
 Adafruit_SPIFlash flash(&flashTransport);
@@ -54,8 +63,11 @@ void setup() {
   // Init external flash
   flash.begin();
 
-  // Init file system on the flash
-  fatfs.begin(&flash);
+  // Open file system on the flash
+  if ( !fatfs.begin(&flash) ) {
+    Serial.println("Error: filesystem is not existed. Please try SdFat_format example to make one.");
+    while(1) yield();
+  }
 
   Serial.println("initialization done.");
 

--- a/examples/flash_info/flash_info.ino
+++ b/examples/flash_info/flash_info.ino
@@ -4,20 +4,28 @@
 #include "SdFat.h"
 #include "Adafruit_SPIFlash.h"
 
-// On-board external flash (QSPI or SPI) macros should already
-// defined in your board variant if supported
-// - EXTERNAL_FLASH_USE_QSPI
-// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-#if defined(EXTERNAL_FLASH_USE_QSPI)
-  Adafruit_FlashTransport_QSPI flashTransport;
+// Uncomment to run example with FRAM
+// #define FRAM_CS   A5
+// #define FRAM_SPI  SPI
 
-#elif defined(EXTERNAL_FLASH_USE_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+#if defined(FRAM_CS) && defined(FRAM_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(FRAM_CS, FRAM_SPI);
 
 #else
-  #error No QSPI/SPI flash are defined on your board variant.h !
-#endif
+  // On-board external flash (QSPI or SPI) macros should already
+  // defined in your board variant if supported
+  // - EXTERNAL_FLASH_USE_QSPI
+  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+  #if defined(EXTERNAL_FLASH_USE_QSPI)
+    Adafruit_FlashTransport_QSPI flashTransport;
 
+  #elif defined(EXTERNAL_FLASH_USE_SPI)
+    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
+  #else
+    #error No QSPI/SPI flash are defined on your board variant.h !
+  #endif
+#endif
 
 Adafruit_SPIFlash flash(&flashTransport);
 
@@ -25,7 +33,7 @@ Adafruit_SPIFlash flash(&flashTransport);
 void setup()
 {
   Serial.begin(115200);
-  while ( !Serial ) delay(10);   // wait for native usb
+  while ( !Serial ) delay(100);   // wait for native usb
 
   flash.begin();
   

--- a/examples/flash_speedtest/flash_speedtest.ino
+++ b/examples/flash_speedtest/flash_speedtest.ino
@@ -111,6 +111,7 @@ bool write_and_compare(uint8_t pattern)
   for(uint32_t addr = 0; addr < flash_sz; addr += sizeof(bufread))
   {
     memset(bufread, 0, sizeof(bufread));
+
     ms = millis();
     flash.readBuffer(addr, bufread, sizeof(bufread));
     ms_read += millis() - ms;

--- a/examples/flash_speedtest/flash_speedtest.ino
+++ b/examples/flash_speedtest/flash_speedtest.ino
@@ -1,0 +1,111 @@
+// The MIT License (MIT)
+// Copyright (c) 2019 Ha Thach for Adafruit Industries
+
+#include "SdFat.h"
+#include "Adafruit_SPIFlash.h"
+
+#if 1
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+  Adafruit_FlashTransport_QSPI flashTransport;
+
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
+#else
+  #error No QSPI/SPI flash are defined on your board variant.h !
+#endif
+
+#else
+  Adafruit_FlashTransport_SPI flashTransport(A5, SPI);
+
+#endif
+
+Adafruit_SPIFlash flash(&flashTransport);
+
+#define BUFSIZE   4096
+
+uint8_t bufwrite[BUFSIZE];
+uint8_t bufread[BUFSIZE];
+
+// the setup function runs once when you press reset or power the board
+void setup()
+{
+  Serial.begin(115200);
+  while ( !Serial ) delay(100);   // wait for native usb
+
+  flash.begin();
+
+  Serial.println("Adafruit Serial Flash Info example");
+  Serial.print("JEDEC ID: "); Serial.println(flash.getJEDECID(), HEX);
+  Serial.print("Flash size: "); Serial.println(flash.size());
+
+  write_and_compare(0xAA);
+}
+
+void print_speed(const char* text, uint32_t count, uint32_t ms)
+{
+  Serial.print(text);
+  Serial.print(count);
+  Serial.print(" bytes in ");
+  Serial.print(ms / 1000.0F, 2);
+  Serial.println(" seconds.");
+
+  Serial.print("Speed : ");
+  Serial.print( (count / 1000.0F) / (ms / 1000.0F), 2);
+  Serial.println(" KB/s.\r\n");
+}
+
+bool write_and_compare(uint8_t pattern)
+{
+  uint32_t ms;
+  uint32_t const flash_sz = flash.size();
+
+  Serial.println("Erase chip");
+  Serial.flush();
+  flash.eraseChip();
+
+  // write all
+  memset(bufwrite, (int) pattern, sizeof(bufwrite));
+  Serial.printf("Write flash with 0x%02X\n", pattern);
+  Serial.flush();
+  ms = millis();
+
+  for(uint32_t addr = 0; addr < flash_sz; addr += sizeof(bufwrite))
+  {
+    flash.writeBuffer(addr, bufwrite, sizeof(bufwrite));
+  }
+
+  uint32_t ms_write = millis() - ms;
+  print_speed("Write ", flash_sz, ms_write);
+  Serial.flush();
+
+  // read and compare
+  Serial.println("Read flash and compare");
+  Serial.flush();
+  ms = millis();
+  for(uint32_t addr = 0; addr < flash_sz; addr += sizeof(bufread))
+  {
+    flash.readBuffer(addr, bufread, sizeof(bufread));
+
+    if ( memcmp(bufwrite, bufread, BUFSIZE) )
+    {
+      Serial.printf("Error: flash contents mismatched at address 0x08X!!!", addr);
+      return false;
+    }
+  }
+
+  uint32_t ms_read = millis() - ms;
+  print_speed("Read  ", flash_sz, ms_read);
+  Serial.flush();
+
+  return true;
+}
+
+void loop()
+{
+  // nothing to do
+}

--- a/src/Adafruit_FlashTransport.h
+++ b/src/Adafruit_FlashTransport.h
@@ -110,9 +110,7 @@ public:
   virtual bool writeMemory(uint32_t addr, uint8_t const *data,
                            uint32_t len) = 0;
 
-  void setReadCommand(uint8_t cmd_read) {
-    _cmd_read = cmd_read;
-  }
+  void setReadCommand(uint8_t cmd_read) { _cmd_read = cmd_read; }
 
 protected:
   // Command use for read operation

--- a/src/Adafruit_FlashTransport.h
+++ b/src/Adafruit_FlashTransport.h
@@ -30,6 +30,7 @@
 
 enum {
   SFLASH_CMD_READ = 0x03,      // Single Read
+  SFLASH_CMD_FAST_READ = 0x0B, // Fast Read
   SFLASH_CMD_QUAD_READ = 0x6B, // 1 line address, 4 line data
 
   SFLASH_CMD_READ_JEDEC_ID = 0x9f,
@@ -107,6 +108,14 @@ public:
   /// @return true if success
   virtual bool writeMemory(uint32_t addr, uint8_t const *data,
                            uint32_t len) = 0;
+
+  void setReadCommand(uint8_t cmd_read) {
+    _cmd_read = cmd_read;
+  }
+
+protected:
+  // Command use for read operation
+  uint8_t _cmd_read;
 };
 
 #include "qspi/Adafruit_FlashTransport_QSPI.h"

--- a/src/Adafruit_FlashTransport.h
+++ b/src/Adafruit_FlashTransport.h
@@ -62,8 +62,9 @@ public:
   virtual bool supportQuadMode(void) = 0;
 
   /// Set clock speed in hertz
-  /// @param clock_hz clock speed in hertz
-  virtual void setClockSpeed(uint32_t clock_hz) = 0;
+  /// @param write_hz Write clock speed in hertz
+  /// @param read_hz  Read  clock speed in hertz
+  virtual void setClockSpeed(uint32_t write_hz, uint32_t read_hz) = 0;
 
   /// Execute a single byte command e.g Reset, Write Enable
   /// @param command command code

--- a/src/Adafruit_SPIFlash.cpp
+++ b/src/Adafruit_SPIFlash.cpp
@@ -25,14 +25,14 @@ Adafruit_SPIFlash::Adafruit_SPIFlash(Adafruit_FlashTransport *transport)
   _cache = NULL;
 }
 
-bool Adafruit_SPIFlash::begin(SPIFlash_Device_t const *flash_devs, size_t count)
-{
+bool Adafruit_SPIFlash::begin(SPIFlash_Device_t const *flash_devs,
+                              size_t count) {
   bool ret = Adafruit_SPIFlashBase::begin(flash_devs, count);
 
   // Use cache if not FRAM
   if (!_flash_dev->is_fram) {
     // new cache object if not already
-    if ( !_cache ) {
+    if (!_cache) {
       _cache = new Adafruit_FlashCache();
     }
   }
@@ -50,7 +50,7 @@ bool Adafruit_SPIFlash::readBlock(uint32_t block, uint8_t *dst) {
   if (_flash_dev->is_fram) {
     // FRAM does not need caching
     return this->readBuffer(block * 512, dst, 512) > 0;
-  }else {
+  } else {
     return _cache->read(this, block * 512, dst, 512);
   }
 }
@@ -60,7 +60,7 @@ bool Adafruit_SPIFlash::syncBlocks() {
 
   if (_flash_dev->is_fram) {
     return true;
-  }else{
+  } else {
     return _cache->sync(this);
   }
 }
@@ -70,7 +70,7 @@ bool Adafruit_SPIFlash::writeBlock(uint32_t block, const uint8_t *src) {
 
   if (_flash_dev->is_fram) {
     return this->writeBuffer(block * 512, src, 512) > 0;
-  }else{
+  } else {
     return _cache->write(this, block * 512, src, 512);
   }
 }
@@ -80,7 +80,7 @@ bool Adafruit_SPIFlash::readBlocks(uint32_t block, uint8_t *dst, size_t nb) {
 
   if (_flash_dev->is_fram) {
     return this->readBuffer(block * 512, dst, 512 * nb) > 0;
-  }else{
+  } else {
     return _cache->read(this, block * 512, dst, 512 * nb);
   }
 }
@@ -90,7 +90,7 @@ bool Adafruit_SPIFlash::writeBlocks(uint32_t block, const uint8_t *src,
   SPIFLASH_LOG(block, nb);
   if (_flash_dev->is_fram) {
     return this->writeBuffer(block * 512, src, 512 * nb) > 0;
-  }else{
+  } else {
     return _cache->write(this, block * 512, src, 512 * nb);
   }
 }

--- a/src/Adafruit_SPIFlash.cpp
+++ b/src/Adafruit_SPIFlash.cpp
@@ -27,26 +27,51 @@ Adafruit_SPIFlash::Adafruit_SPIFlash(Adafruit_FlashTransport *transport)
 //--------------------------------------------------------------------+
 bool Adafruit_SPIFlash::readBlock(uint32_t block, uint8_t *dst) {
   SPIFLASH_LOG(block, 1);
-  return _cache.read(this, block * 512, dst, 512);
+
+  if (_flash_dev->is_fram) {
+    // FRAM does not need caching
+    return this->readBuffer(block * 512, dst, 512) > 0;
+  }else {
+    return _cache.read(this, block * 512, dst, 512);
+  }
 }
 
 bool Adafruit_SPIFlash::syncBlocks() {
   SPIFLASH_LOG(0, 0);
-  return _cache.sync(this);
+
+  if (_flash_dev->is_fram) {
+    return true;
+  }else{
+    return _cache.sync(this);
+  }
 }
 
 bool Adafruit_SPIFlash::writeBlock(uint32_t block, const uint8_t *src) {
   SPIFLASH_LOG(block, 1);
-  return _cache.write(this, block * 512, src, 512);
+
+  if (_flash_dev->is_fram) {
+    return this->writeBuffer(block * 512, src, 512) > 0;
+  }else{
+    return _cache.write(this, block * 512, src, 512);
+  }
 }
 
 bool Adafruit_SPIFlash::readBlocks(uint32_t block, uint8_t *dst, size_t nb) {
   SPIFLASH_LOG(block, nb);
-  return _cache.read(this, block * 512, dst, 512 * nb);
+
+  if (_flash_dev->is_fram) {
+    return this->readBuffer(block * 512, dst, 512 * nb) > 0;
+  }else{
+    return _cache.read(this, block * 512, dst, 512 * nb);
+  }
 }
 
 bool Adafruit_SPIFlash::writeBlocks(uint32_t block, const uint8_t *src,
                                     size_t nb) {
   SPIFLASH_LOG(block, nb);
-  return _cache.write(this, block * 512, src, 512 * nb);
+  if (_flash_dev->is_fram) {
+    return this->writeBuffer(block * 512, src, 512 * nb) > 0;
+  }else{
+    return _cache.write(this, block * 512, src, 512 * nb);
+  }
 }

--- a/src/Adafruit_SPIFlash.h
+++ b/src/Adafruit_SPIFlash.h
@@ -63,7 +63,7 @@ public:
   virtual bool writeBlocks(uint32_t block, const uint8_t *src, size_t nb);
 
 private:
-  Adafruit_FlashCache* _cache;
+  Adafruit_FlashCache *_cache;
 };
 
 #endif /* ADAFRUIT_SPIFLASH_H_ */

--- a/src/Adafruit_SPIFlash.h
+++ b/src/Adafruit_SPIFlash.h
@@ -53,6 +53,8 @@ public:
   Adafruit_SPIFlash(Adafruit_FlashTransport *transport);
   ~Adafruit_SPIFlash() {}
 
+  bool begin(SPIFlash_Device_t const *flash_devs = NULL, size_t count = 1);
+
   //------------- SdFat BaseBlockDRiver API -------------//
   virtual bool readBlock(uint32_t block, uint8_t *dst);
   virtual bool syncBlocks();
@@ -61,7 +63,7 @@ public:
   virtual bool writeBlocks(uint32_t block, const uint8_t *src, size_t nb);
 
 private:
-  Adafruit_FlashCache _cache;
+  Adafruit_FlashCache* _cache;
 };
 
 #endif /* ADAFRUIT_SPIFLASH_H_ */

--- a/src/Adafruit_SPIFlashBase.cpp
+++ b/src/Adafruit_SPIFlashBase.cpp
@@ -138,8 +138,8 @@ bool Adafruit_SPIFlashBase::begin(SPIFlash_Device_t const *flash_devs,
   if (_flash_dev->is_fram) {
     // Initial testing on breadboard, max clock speed to work reliably with FRAM is slower than supported specs
     // - nRF52840: 16 Mhz  with DMA write/read ~ 2000 KB/s
-    // - SAMD M4 : 24 Mhz, no   DMA write/read ~ 1300 KB/s
-    // - SAMD M0 : 12 Mhz, no   DMA write/read ~  500 KB/s
+    // - SAMD M4 : 24 Mhz, DMA write ~ 3000 KB/s, no DMA read ~ 1300 KB/s
+    // - SAMD M0 : 12 Mhz, DMA write ~1400 KB/s, no DMA read ~ 500 KB/s
 #if defined ARDUINO_NRF52_ADAFRUIT
     max_speed = 16000000;
 #elif defined ARDUINO_ARCH_SAMD

--- a/src/Adafruit_SPIFlashBase.cpp
+++ b/src/Adafruit_SPIFlashBase.cpp
@@ -128,7 +128,7 @@ bool Adafruit_SPIFlashBase::begin(SPIFlash_Device_t const *flash_devs,
 
   // Speed up to max device frequency, or as high as possible
   uint32_t clock_speed = min((uint32_t)(_flash_dev->max_clock_speed_mhz * 1000000U), (uint32_t) F_CPU);
-  PRINT_INT(clock_speed);
+//  PRINT_INT(clock_speed);
   _trans->setClockSpeed(clock_speed);
 
   // Enable Quad Mode if available

--- a/src/Adafruit_SPIFlashBase.cpp
+++ b/src/Adafruit_SPIFlashBase.cpp
@@ -129,11 +129,14 @@ bool Adafruit_SPIFlashBase::begin(SPIFlash_Device_t const *flash_devs,
   }
 
   // Speed up to max device frequency, or as high as possible
-  _trans->setClockSpeed(min(
-      (uint32_t)(_flash_dev->max_clock_speed_mhz * 1000000U), (uint32_t)F_CPU));
+  uint32_t clock_speed = min((uint32_t)(_flash_dev->max_clock_speed_mhz * 1000000U), (uint32_t) F_CPU);
+  //PRINT_INT(clock_speed);
+
+  _trans->setClockSpeed(clock_speed);
+
 
   // Enable Quad Mode if available
-  if (_trans->supportQuadMode() && (_flash_dev->supports_qspi)) {
+  if (_trans->supportQuadMode() && _flash_dev->supports_qspi) {
     // Verify that QSPI mode is enabled.
     uint8_t status =
         _flash_dev->single_status_byte ? readStatus() : readStatus2();
@@ -151,6 +154,11 @@ bool Adafruit_SPIFlashBase::begin(SPIFlash_Device_t const *flash_devs,
       } else {
         _trans->writeCommand(SFLASH_CMD_WRITE_STATUS, full_status, 2);
       }
+    }
+  }else {
+    // Single mode, use fast read if supported
+    if ( _flash_dev->supports_fast_read ) {
+      _trans->setReadCommand(SFLASH_CMD_FAST_READ);
     }
   }
 

--- a/src/Adafruit_SPIFlashBase.cpp
+++ b/src/Adafruit_SPIFlashBase.cpp
@@ -35,8 +35,10 @@ static const SPIFlash_Device_t possible_devices[] = {
     W25Q16FW,
     W25Q64JV_IQ,
 
-    // Fujitsu FRAM
+    // Fujitsu FRAM 128/256/512 KBs
+    MB85RS1MT,
     MB85RS2MTA,
+    MB85RS4MT,
 
     // Nordic PCA10056
     MX25R6435F,
@@ -95,6 +97,7 @@ bool Adafruit_SPIFlashBase::begin(SPIFlash_Device_t const *flash_devs,
   if (flash_devs != NULL) {
     _flash_dev = findDevice(flash_devs, count, jedec_ids);
   }
+
   // If not found, check for device in standard list.
   if (_flash_dev == NULL) {
     _flash_dev =
@@ -102,6 +105,8 @@ bool Adafruit_SPIFlashBase::begin(SPIFlash_Device_t const *flash_devs,
   }
 
   if (_flash_dev == NULL) {
+    Serial.print("Unknown flash device 0x");
+    Serial.println(jedec_ids[0] << 16 | jedec_ids[1] << 8 | jedec_ids[2], HEX);
     return false;
   }
 

--- a/src/Adafruit_SPIFlashBase.cpp
+++ b/src/Adafruit_SPIFlashBase.cpp
@@ -91,8 +91,6 @@ bool Adafruit_SPIFlashBase::begin(SPIFlash_Device_t const *flash_devs,
   uint8_t jedec_ids[3];
   _trans->readCommand(SFLASH_CMD_READ_JEDEC_ID, jedec_ids, 3);
 
-  //PRINTF("jedec_ids = %02X-%02X-%02X\r\n", jedec_ids[0], jedec_ids[1], jedec_ids[2]); delay(10);
-
   // Check for device in supplied list, if any.
   if (flash_devs != NULL) {
     _flash_dev = findDevice(flash_devs, count, jedec_ids);
@@ -130,10 +128,8 @@ bool Adafruit_SPIFlashBase::begin(SPIFlash_Device_t const *flash_devs,
 
   // Speed up to max device frequency, or as high as possible
   uint32_t clock_speed = min((uint32_t)(_flash_dev->max_clock_speed_mhz * 1000000U), (uint32_t) F_CPU);
-  //PRINT_INT(clock_speed);
-
+  PRINT_INT(clock_speed);
   _trans->setClockSpeed(clock_speed);
-
 
   // Enable Quad Mode if available
   if (_trans->supportQuadMode() && _flash_dev->supports_qspi) {

--- a/src/Adafruit_SPIFlashBase.h
+++ b/src/Adafruit_SPIFlashBase.h
@@ -81,17 +81,17 @@ protected:
   Adafruit_FlashTransport *_trans;
   SPIFlash_Device_t const *_flash_dev;
 
-  int  _ind_pin;
+  int _ind_pin;
   bool _ind_active;
 
   void _indicator_on(void) {
-    if (_ind_pin >= 0 ) {
+    if (_ind_pin >= 0) {
       digitalWrite(_ind_pin, _ind_active ? HIGH : LOW);
     }
   }
 
   void _indicator_off(void) {
-    if (_ind_pin >= 0 ) {
+    if (_ind_pin >= 0) {
       digitalWrite(_ind_pin, _ind_active ? LOW : HIGH);
     }
   }

--- a/src/Adafruit_SPIFlashBase.h
+++ b/src/Adafruit_SPIFlashBase.h
@@ -50,6 +50,8 @@ public:
   bool begin(SPIFlash_Device_t const *flash_devs = NULL, size_t count = 1);
   bool end(void);
 
+  void setIndicator(int pin, bool state_on = true);
+
   uint16_t numPages(void);
   uint16_t pageSize(void);
 
@@ -59,6 +61,7 @@ public:
   uint8_t readStatus2(void);
   void waitUntilReady(void);
   bool writeEnable(void);
+  bool writeDisable(void);
 
   uint32_t getJEDECID(void);
 
@@ -77,6 +80,21 @@ public:
 private:
   Adafruit_FlashTransport *_trans;
   SPIFlash_Device_t const *_flash_dev;
+
+  int  _ind_pin;
+  bool _ind_active;
+
+  void _indicator_on(void) {
+    if (_ind_pin >= 0 ) {
+      digitalWrite(_ind_pin, _ind_active ? HIGH : LOW);
+    }
+  }
+
+  void _indicator_off(void) {
+    if (_ind_pin >= 0 ) {
+      digitalWrite(_ind_pin, _ind_active ? LOW : HIGH);
+    }
+  }
 };
 
 // for debugging

--- a/src/Adafruit_SPIFlashBase.h
+++ b/src/Adafruit_SPIFlashBase.h
@@ -77,7 +77,7 @@ public:
   uint16_t read16(uint32_t addr);
   uint32_t read32(uint32_t addr);
 
-private:
+protected:
   Adafruit_FlashTransport *_trans;
   SPIFlash_Device_t const *_flash_dev;
 

--- a/src/flash_devices.h
+++ b/src/flash_devices.h
@@ -121,9 +121,8 @@ typedef struct {
   {                                                                            \
     .total_size = (1 << 17), /* 128 KiB */                                     \
         .start_up_time_us = 5000, .manufacturer_id = 0x04,                     \
-    .memory_type = 0x7F, .capacity = 0x27,                                     \
-    .max_clock_speed_mhz = 40,                                                 \
-        .quad_enable_bit_mask = 0x00, .has_sector_protection = false,          \
+    .memory_type = 0x7F, .capacity = 0x27, .max_clock_speed_mhz = 40,          \
+    .quad_enable_bit_mask = 0x00, .has_sector_protection = false,              \
     .supports_fast_read = true, .supports_qspi = false,                        \
     .supports_qspi_writes = true, .write_status_register_split = false,        \
     .single_status_byte = true, .is_fram = true,                               \
@@ -134,9 +133,8 @@ typedef struct {
   {                                                                            \
     .total_size = (1 << 18), /* 256 KiB */                                     \
         .start_up_time_us = 5000, .manufacturer_id = 0x04,                     \
-    .memory_type = 0x7F, .capacity = 0x48,                                     \
-    .max_clock_speed_mhz = 40,                                                 \
-        .quad_enable_bit_mask = 0x00, .has_sector_protection = false,          \
+    .memory_type = 0x7F, .capacity = 0x48, .max_clock_speed_mhz = 40,          \
+    .quad_enable_bit_mask = 0x00, .has_sector_protection = false,              \
     .supports_fast_read = true, .supports_qspi = false,                        \
     .supports_qspi_writes = true, .write_status_register_split = false,        \
     .single_status_byte = true, .is_fram = true,                               \
@@ -147,9 +145,8 @@ typedef struct {
   {                                                                            \
     .total_size = (1 << 19), /* 512 KiB */                                     \
         .start_up_time_us = 5000, .manufacturer_id = 0x04,                     \
-    .memory_type = 0x7F, .capacity = 0x49,                                     \
-    .max_clock_speed_mhz = 40,                                                 \
-        .quad_enable_bit_mask = 0x00, .has_sector_protection = false,          \
+    .memory_type = 0x7F, .capacity = 0x49, .max_clock_speed_mhz = 40,          \
+    .quad_enable_bit_mask = 0x00, .has_sector_protection = false,              \
     .supports_fast_read = true, .supports_qspi = false,                        \
     .supports_qspi_writes = true, .write_status_register_split = false,        \
     .single_status_byte = true, .is_fram = true,                               \

--- a/src/flash_devices.h
+++ b/src/flash_devices.h
@@ -117,7 +117,17 @@ typedef struct {
   }
 
 // https://www.fujitsu.com/uk/Images/MB85RS1MT.pdf
-#define MB85RS1MT
+#define MB85RS1MT                                                              \
+  {                                                                            \
+    .total_size = (1 << 17), /* 128 KiB */                                     \
+        .start_up_time_us = 5000, .manufacturer_id = 0x04,                     \
+    .memory_type = 0x7F, .capacity = 0x27,                                     \
+    .max_clock_speed_mhz = 40,                                                 \
+        .quad_enable_bit_mask = 0x00, .has_sector_protection = false,          \
+    .supports_fast_read = true, .supports_qspi = false,                        \
+    .supports_qspi_writes = true, .write_status_register_split = false,        \
+    .single_status_byte = true, .is_fram = true,                               \
+  }
 
 // https://www.fujitsu.com/uk/Images/MB85RS2MTA.pdf
 #define MB85RS2MTA                                                             \
@@ -132,6 +142,18 @@ typedef struct {
     .single_status_byte = true, .is_fram = true,                               \
   }
 
+// https://www.fujitsu.com/uk/Images/MB85RS4MT.pdf
+#define MB85RS4MT                                                              \
+  {                                                                            \
+    .total_size = (1 << 19), /* 512 KiB */                                     \
+        .start_up_time_us = 5000, .manufacturer_id = 0x04,                     \
+    .memory_type = 0x7F, .capacity = 0x49,                                     \
+    .max_clock_speed_mhz = 40,                                                 \
+        .quad_enable_bit_mask = 0x00, .has_sector_protection = false,          \
+    .supports_fast_read = true, .supports_qspi = false,                        \
+    .supports_qspi_writes = true, .write_status_register_split = false,        \
+    .single_status_byte = true, .is_fram = true,                               \
+  }
 
 // Settings for the Cypress (was Spansion) S25FL064L 8MiB SPI flash.
 // Datasheet: http://www.cypress.com/file/316661/download

--- a/src/flash_devices.h
+++ b/src/flash_devices.h
@@ -65,6 +65,10 @@ typedef struct {
   // Enable bit is in the first byte and the Read Status Register 2 command
   // (0x35) is unsupported.
   bool single_status_byte : 1;
+
+  // Fram does not need/support erase and has much simpler WRITE operation
+  bool is_fram : 1;
+
 } SPIFlash_Device_t;
 
 // Settings for the Adesto Tech AT25DF081A 1MiB SPI flash. Its on the SAMD21
@@ -78,7 +82,7 @@ typedef struct {
     .quad_enable_bit_mask = 0x00, .has_sector_protection = true,               \
     .supports_fast_read = true, .supports_qspi = false,                        \
     .supports_qspi_writes = false, .write_status_register_split = false,       \
-    .single_status_byte = false,                                               \
+    .single_status_byte = false, .is_fram = false,                             \
   }
 
 // Settings for the Gigadevice GD25Q16C 2MiB SPI flash.
@@ -93,7 +97,7 @@ typedef struct {
         .quad_enable_bit_mask = 0x02, .has_sector_protection = false,          \
     .supports_fast_read = true, .supports_qspi = true,                         \
     .supports_qspi_writes = true, .write_status_register_split = false,        \
-    .single_status_byte = false,                                               \
+    .single_status_byte = false, .is_fram = false,                             \
   }
 
 // Settings for the Gigadevice GD25Q64C 8MiB SPI flash.
@@ -109,7 +113,7 @@ typedef struct {
         .quad_enable_bit_mask = 0x02, .has_sector_protection = false,          \
     .supports_fast_read = true, .supports_qspi = true,                         \
     .supports_qspi_writes = true, .write_status_register_split = true,         \
-    .single_status_byte = false,                                               \
+    .single_status_byte = false, .is_fram = false,                             \
   }
 
 // https://www.fujitsu.com/uk/Images/MB85RS1MT.pdf
@@ -125,7 +129,7 @@ typedef struct {
         .quad_enable_bit_mask = 0x00, .has_sector_protection = false,          \
     .supports_fast_read = true, .supports_qspi = false,                        \
     .supports_qspi_writes = true, .write_status_register_split = false,        \
-    .single_status_byte = true,                                                \
+    .single_status_byte = true, .is_fram = true,                               \
   }
 
 
@@ -139,7 +143,7 @@ typedef struct {
     .quad_enable_bit_mask = 0x02, .has_sector_protection = false,              \
     .supports_fast_read = true, .supports_qspi = true,                         \
     .supports_qspi_writes = true, .write_status_register_split = false,        \
-    .single_status_byte = false,                                               \
+    .single_status_byte = false, .is_fram = false,                             \
   }
 
 // Settings for the Cypress (was Spansion) S25FL116K 2MiB SPI flash.
@@ -152,7 +156,7 @@ typedef struct {
     .quad_enable_bit_mask = 0x02, .has_sector_protection = false,              \
     .supports_fast_read = true, .supports_qspi = true,                         \
     .supports_qspi_writes = false, .write_status_register_split = false,       \
-    .single_status_byte = false,                                               \
+    .single_status_byte = false, .is_fram = false,                             \
   }
 
 // Settings for the Cypress (was Spansion) S25FL216K 2MiB SPI flash.
@@ -165,7 +169,7 @@ typedef struct {
     .quad_enable_bit_mask = 0x02, .has_sector_protection = false,              \
     .supports_fast_read = true, .supports_qspi = false,                        \
     .supports_qspi_writes = false, .write_status_register_split = false,       \
-    .single_status_byte = false,                                               \
+    .single_status_byte = false, .is_fram = false,                             \
   }
 
 // Settings for the Winbond W25Q16FW 2MiB SPI flash.
@@ -179,7 +183,7 @@ typedef struct {
     .quad_enable_bit_mask = 0x02, .has_sector_protection = false,              \
     .supports_fast_read = true, .supports_qspi = true,                         \
     .supports_qspi_writes = true, .write_status_register_split = false,        \
-    .single_status_byte = false,                                               \
+    .single_status_byte = false, .is_fram = false,                             \
   }
 
 // Settings for the Winbond W25Q16JV-IQ 2MiB SPI flash. Note that JV-IM has a
@@ -193,7 +197,7 @@ typedef struct {
     .quad_enable_bit_mask = 0x02, .has_sector_protection = false,              \
     .supports_fast_read = true, .supports_qspi = true,                         \
     .supports_qspi_writes = true, .write_status_register_split = false,        \
-    .single_status_byte = false,                                               \
+    .single_status_byte = false, .is_fram = false,                             \
   }
 
 // Settings for the Winbond W25Q16JV-IM 2MiB SPI flash. Note that JV-IQ has a
@@ -220,7 +224,7 @@ typedef struct {
     .quad_enable_bit_mask = 0x02, .has_sector_protection = false,              \
     .supports_fast_read = true, .supports_qspi = true,                         \
     .supports_qspi_writes = false, .write_status_register_split = false,       \
-    .single_status_byte = false,                                               \
+    .single_status_byte = false, .is_fram = false,                             \
   }
 // Settings for the Winbond W25Q32JV-IM 4MiB SPI flash.
 // Datasheet:
@@ -246,7 +250,7 @@ typedef struct {
     .quad_enable_bit_mask = 0x02, .has_sector_protection = false,              \
     .supports_fast_read = true, .supports_qspi = true,                         \
     .supports_qspi_writes = true, .write_status_register_split = false,        \
-    .single_status_byte = false,                                               \
+    .single_status_byte = false, .is_fram = false,                             \
   }
 
 // Settings for the Winbond W25Q64JV-IQ 8MiB SPI flash. Note that JV-IM has a
@@ -260,7 +264,7 @@ typedef struct {
     .quad_enable_bit_mask = 0x02, .has_sector_protection = false,              \
     .supports_fast_read = true, .supports_qspi = true,                         \
     .supports_qspi_writes = true, .write_status_register_split = false,        \
-    .single_status_byte = false,                                               \
+    .single_status_byte = false, .is_fram = false,                             \
   }
 
 // Settings for the Winbond W25Q80DL 1MiB SPI flash.
@@ -274,7 +278,7 @@ typedef struct {
     .quad_enable_bit_mask = 0x02, .has_sector_protection = false,              \
     .supports_fast_read = true, .supports_qspi = true,                         \
     .supports_qspi_writes = false, .write_status_register_split = false,       \
-    .single_status_byte = false,                                               \
+    .single_status_byte = false, .is_fram = false,                             \
   }
 
 // Settings for the Winbond W25Q128JV-SQ 16MiB SPI flash. Note that JV-IM has a
@@ -288,7 +292,7 @@ typedef struct {
     .quad_enable_bit_mask = 0x02, .has_sector_protection = false,              \
     .supports_fast_read = true, .supports_qspi = true,                         \
     .supports_qspi_writes = true, .write_status_register_split = false,        \
-    .single_status_byte = false,                                               \
+    .single_status_byte = false, .is_fram = false,                             \
   }
 
 // Settings for the Macronix MX25L1606 2MiB SPI flash.
@@ -301,7 +305,7 @@ typedef struct {
     .quad_enable_bit_mask = 0x40, .has_sector_protection = false,              \
     .supports_fast_read = true, .supports_qspi = true,                         \
     .supports_qspi_writes = true, .write_status_register_split = false,        \
-    .single_status_byte = true,                                                \
+    .single_status_byte = true, .is_fram = false,                              \
   }
 
 // Settings for the Macronix MX25L3233F 4MiB SPI flash.
@@ -315,7 +319,7 @@ typedef struct {
     .quad_enable_bit_mask = 0x40, .has_sector_protection = false,              \
     .supports_fast_read = true, .supports_qspi = true,                         \
     .supports_qspi_writes = true, .write_status_register_split = false,        \
-    .single_status_byte = true,                                                \
+    .single_status_byte = true, .is_fram = false,                              \
   }
 
 // Settings for the Macronix MX25R6435F 8MiB SPI flash.
@@ -331,7 +335,7 @@ typedef struct {
     .quad_enable_bit_mask = 0x40, .has_sector_protection = false,              \
     .supports_fast_read = true, .supports_qspi = true,                         \
     .supports_qspi_writes = true, .write_status_register_split = false,        \
-    .single_status_byte = true,                                                \
+    .single_status_byte = true, .is_fram = false,                              \
   }
 
 // Settings for the Winbond W25Q128JV-PM 16MiB SPI flash. Note that JV-IM has a
@@ -357,6 +361,6 @@ typedef struct {
     .quad_enable_bit_mask = 0x00, .has_sector_protection = false,              \
     .supports_fast_read = true, .supports_qspi = false,                        \
     .supports_qspi_writes = false, .write_status_register_split = false,       \
-    .single_status_byte = false,                                               \
+    .single_status_byte = false, .is_fram = false,                             \
   }
 #endif // MICROPY_INCLUDED_ATMEL_SAMD_EXTERNAL_FLASH_DEVICES_H

--- a/src/flash_devices.h
+++ b/src/flash_devices.h
@@ -112,6 +112,23 @@ typedef struct {
     .single_status_byte = false,                                               \
   }
 
+// https://www.fujitsu.com/uk/Images/MB85RS1MT.pdf
+#define MB85RS1MT
+
+// https://www.fujitsu.com/uk/Images/MB85RS2MTA.pdf
+#define MB85RS2MTA                                                             \
+  {                                                                            \
+    .total_size = (1 << 18), /* 256 KiB */                                     \
+        .start_up_time_us = 5000, .manufacturer_id = 0x04,                     \
+    .memory_type = 0x7F, .capacity = 0x48,                                     \
+    .max_clock_speed_mhz = 40,                                                 \
+        .quad_enable_bit_mask = 0x00, .has_sector_protection = false,          \
+    .supports_fast_read = true, .supports_qspi = false,                        \
+    .supports_qspi_writes = true, .write_status_register_split = false,        \
+    .single_status_byte = true,                                                \
+  }
+
+
 // Settings for the Cypress (was Spansion) S25FL064L 8MiB SPI flash.
 // Datasheet: http://www.cypress.com/file/316661/download
 #define S25FL064L                                                              \

--- a/src/qspi/Adafruit_FlashTransport_QSPI.h
+++ b/src/qspi/Adafruit_FlashTransport_QSPI.h
@@ -39,7 +39,7 @@ public:
 
   virtual bool supportQuadMode(void) { return true; }
 
-  virtual void setClockSpeed(uint32_t clock_hz);
+  virtual void setClockSpeed(uint32_t write_hz, uint32_t read_hz);
 
   virtual bool runCommand(uint8_t command);
   virtual bool readCommand(uint8_t command, uint8_t *response, uint32_t len);

--- a/src/qspi/Adafruit_FlashTransport_QSPI_NRF.cpp
+++ b/src/qspi/Adafruit_FlashTransport_QSPI_NRF.cpp
@@ -75,8 +75,9 @@ void Adafruit_FlashTransport_QSPI::begin(void) {
   nrfx_qspi_init(&qspi_cfg, NULL, NULL);
 }
 
-void Adafruit_FlashTransport_QSPI::setClockSpeed(uint32_t clock_hz, uint32_t read_hz) {
-  (void) read_hz;
+void Adafruit_FlashTransport_QSPI::setClockSpeed(uint32_t clock_hz,
+                                                 uint32_t read_hz) {
+  (void)read_hz;
   // Start at 16 MHz and go down.
   // At 32 MHz nRF52840 doesn't work reliably !!!
   // clkdiv = 0 is 32 Mhz

--- a/src/qspi/Adafruit_FlashTransport_QSPI_NRF.cpp
+++ b/src/qspi/Adafruit_FlashTransport_QSPI_NRF.cpp
@@ -36,6 +36,7 @@ Adafruit_FlashTransport_QSPI::Adafruit_FlashTransport_QSPI(void)
 
 Adafruit_FlashTransport_QSPI::Adafruit_FlashTransport_QSPI(
     int8_t sck, int8_t cs, int8_t io0, int8_t io1, int8_t io2, int8_t io3) {
+  _cmd_read = SFLASH_CMD_QUAD_READ;
   _sck = sck;
   _cs = cs;
   _io0 = io0;

--- a/src/qspi/Adafruit_FlashTransport_QSPI_NRF.cpp
+++ b/src/qspi/Adafruit_FlashTransport_QSPI_NRF.cpp
@@ -75,7 +75,8 @@ void Adafruit_FlashTransport_QSPI::begin(void) {
   nrfx_qspi_init(&qspi_cfg, NULL, NULL);
 }
 
-void Adafruit_FlashTransport_QSPI::setClockSpeed(uint32_t clock_hz) {
+void Adafruit_FlashTransport_QSPI::setClockSpeed(uint32_t clock_hz, uint32_t read_hz) {
+  (void) read_hz;
   // Start at 16 MHz and go down.
   // At 32 MHz nRF52840 doesn't work reliably !!!
   // clkdiv = 0 is 32 Mhz

--- a/src/qspi/Adafruit_FlashTransport_QSPI_SAMD.cpp
+++ b/src/qspi/Adafruit_FlashTransport_QSPI_SAMD.cpp
@@ -171,7 +171,8 @@ bool Adafruit_FlashTransport_QSPI::writeMemory(uint32_t addr,
  @param clock_hz clock speed in hertz
  */
 /**************************************************************************/
-void Adafruit_FlashTransport_QSPI::setClockSpeed(uint32_t clock_hz) {
+void Adafruit_FlashTransport_QSPI::setClockSpeed(uint32_t clock_hz, uint32_t read_hz) {
+  (void) read_hz;
   QSPI->BAUD.bit.BAUD = VARIANT_MCK / clock_hz;
 }
 

--- a/src/qspi/Adafruit_FlashTransport_QSPI_SAMD.cpp
+++ b/src/qspi/Adafruit_FlashTransport_QSPI_SAMD.cpp
@@ -49,6 +49,7 @@ Adafruit_FlashTransport_QSPI::Adafruit_FlashTransport_QSPI(void)
 
 Adafruit_FlashTransport_QSPI::Adafruit_FlashTransport_QSPI(
     int8_t sck, int8_t cs, int8_t io0, int8_t io1, int8_t io2, int8_t io3) {
+  _cmd_read = SFLASH_CMD_QUAD_READ;
   _sck = sck;
   _cs = cs;
   _io0 = io0;

--- a/src/qspi/Adafruit_FlashTransport_QSPI_SAMD.cpp
+++ b/src/qspi/Adafruit_FlashTransport_QSPI_SAMD.cpp
@@ -171,8 +171,9 @@ bool Adafruit_FlashTransport_QSPI::writeMemory(uint32_t addr,
  @param clock_hz clock speed in hertz
  */
 /**************************************************************************/
-void Adafruit_FlashTransport_QSPI::setClockSpeed(uint32_t clock_hz, uint32_t read_hz) {
-  (void) read_hz;
+void Adafruit_FlashTransport_QSPI::setClockSpeed(uint32_t clock_hz,
+                                                 uint32_t read_hz) {
+  (void)read_hz;
   QSPI->BAUD.bit.BAUD = VARIANT_MCK / clock_hz;
 }
 

--- a/src/spi/Adafruit_FlashTransport_SPI.cpp
+++ b/src/spi/Adafruit_FlashTransport_SPI.cpp
@@ -150,9 +150,8 @@ bool Adafruit_FlashTransport_SPI::writeMemory(uint32_t addr,
   // Use SPI DMA if available for best performance
 #if defined(ARDUINO_NRF52_ADAFRUIT) && defined(NRF52840_XXAA)
   _spi->transfer(data, NULL, len);
-//#elif defined(ARDUINO_ARCH_SAMD) && defined(_ADAFRUIT_ZERODMA_H_) && !defined(ADAFRUIT_FEATHER_M0_EXPRESS)
-//  // TODO Out of all M0 boards, Feather M0 seems to have issue with SPI DMA writing, other M0 board seems to be fine
-//  _spi->transfer(data, NULL, len, true);
+#elif defined(ARDUINO_ARCH_SAMD) && defined(_ADAFRUIT_ZERODMA_H_)
+  _spi->transfer(data, NULL, len, true);
 #else
   while (len--) {
     _spi->transfer(*data++);

--- a/src/spi/Adafruit_FlashTransport_SPI.cpp
+++ b/src/spi/Adafruit_FlashTransport_SPI.cpp
@@ -123,7 +123,7 @@ bool Adafruit_FlashTransport_SPI::readMemory(uint32_t addr, uint8_t *data,
 #if defined(ARDUINO_NRF52_ADAFRUIT) && defined(NRF52840_XXAA)
   _spi->transfer(NULL, data, len);
 //#elif defined(ARDUINO_ARCH_SAMD) && defined(_ADAFRUIT_ZERODMA_H_)
-//  TODO Could only got the 1st SPI read work, 2nd will failed, maybe we didn't clear thing !!!
+//  // TODO Could only got the 1st SPI read work, 2nd will failed, maybe we didn't clear thing !!!
 //  _spi->transfer(NULL, data, len, true);
 #else
   while (len--) {

--- a/src/spi/Adafruit_FlashTransport_SPI.cpp
+++ b/src/spi/Adafruit_FlashTransport_SPI.cpp
@@ -44,7 +44,8 @@ void Adafruit_FlashTransport_SPI::begin(void) {
   _spi->begin();
 }
 
-void Adafruit_FlashTransport_SPI::setClockSpeed(uint32_t write_hz, uint32_t read_hz) {
+void Adafruit_FlashTransport_SPI::setClockSpeed(uint32_t write_hz,
+                                                uint32_t read_hz) {
   _clock_wr = write_hz;
   _clock_rd = read_hz;
 }
@@ -92,7 +93,8 @@ bool Adafruit_FlashTransport_SPI::eraseCommand(uint8_t command,
                                                uint32_t address) {
   beginTransaction(_clock_wr);
 
-  uint8_t cmd_with_addr[] = { command, (address >> 16) & 0xFF, (address >> 8) & 0xFF, address & 0xFF };
+  uint8_t cmd_with_addr[] = {command, (address >> 16) & 0xFF,
+                             (address >> 8) & 0xFF, address & 0xFF};
 
   _spi->transfer(cmd_with_addr, 4);
 
@@ -105,7 +107,8 @@ bool Adafruit_FlashTransport_SPI::readMemory(uint32_t addr, uint8_t *data,
                                              uint32_t len) {
   beginTransaction(_clock_rd);
 
-  uint8_t cmd_with_addr[5] = { _cmd_read, (addr >> 16) & 0xFF, (addr >> 8) & 0xFF, addr & 0xFF, 0xFF };
+  uint8_t cmd_with_addr[5] = {_cmd_read, (addr >> 16) & 0xFF,
+                              (addr >> 8) & 0xFF, addr & 0xFF, 0xFF};
 
   // Fast Read has 1 extra dummy byte
   _spi->transfer(cmd_with_addr, SFLASH_CMD_FAST_READ == _cmd_read ? 5 : 4);
@@ -114,8 +117,8 @@ bool Adafruit_FlashTransport_SPI::readMemory(uint32_t addr, uint8_t *data,
 #if defined(ARDUINO_NRF52_ADAFRUIT) && defined(NRF52840_XXAA)
   _spi->transfer(NULL, data, len);
 //#elif defined(ARDUINO_ARCH_SAMD) && defined(_ADAFRUIT_ZERODMA_H_)
-//  // TODO Could only got the 1st SPI read work, 2nd will failed, maybe we didn't clear thing !!!
-//  _spi->transfer(NULL, data, len, true);
+//  // TODO Could only got the 1st SPI read work, 2nd will failed, maybe we
+//  didn't clear thing !!! _spi->transfer(NULL, data, len, true);
 #else
   while (len--) {
     *data++ = _spi->transfer(0xFF);
@@ -132,7 +135,8 @@ bool Adafruit_FlashTransport_SPI::writeMemory(uint32_t addr,
                                               uint32_t len) {
   beginTransaction(_clock_wr);
 
-  uint8_t cmd_with_addr[] = { SFLASH_CMD_PAGE_PROGRAM, (addr >> 16) & 0xFF, (addr >> 8) & 0xFF, addr & 0xFF };
+  uint8_t cmd_with_addr[] = {SFLASH_CMD_PAGE_PROGRAM, (addr >> 16) & 0xFF,
+                             (addr >> 8) & 0xFF, addr & 0xFF};
 
   _spi->transfer(cmd_with_addr, 4);
 

--- a/src/spi/Adafruit_FlashTransport_SPI.cpp
+++ b/src/spi/Adafruit_FlashTransport_SPI.cpp
@@ -30,8 +30,7 @@ Adafruit_FlashTransport_SPI::Adafruit_FlashTransport_SPI(
   _cmd_read = SFLASH_CMD_READ;
   _ss = ss;
   _spi = spiinterface;
-  _setting_write = SPISettings();
-  _setting_read = SPISettings();
+  _clock_wr = _clock_rd = 4000000;
 }
 
 Adafruit_FlashTransport_SPI::Adafruit_FlashTransport_SPI(uint8_t ss,
@@ -46,12 +45,12 @@ void Adafruit_FlashTransport_SPI::begin(void) {
 }
 
 void Adafruit_FlashTransport_SPI::setClockSpeed(uint32_t write_hz, uint32_t read_hz) {
-  _setting_write = SPISettings(write_hz, MSBFIRST, SPI_MODE0);
-  _setting_read = SPISettings(read_hz, MSBFIRST, SPI_MODE0);
+  _clock_wr = write_hz;
+  _clock_rd = read_hz;
 }
 
 bool Adafruit_FlashTransport_SPI::runCommand(uint8_t command) {
-  beginTransaction(_setting_write);
+  beginTransaction(_clock_wr);
 
   _spi->transfer(command);
 
@@ -62,7 +61,7 @@ bool Adafruit_FlashTransport_SPI::runCommand(uint8_t command) {
 
 bool Adafruit_FlashTransport_SPI::readCommand(uint8_t command,
                                               uint8_t *response, uint32_t len) {
-  beginTransaction(_setting_read);
+  beginTransaction(_clock_rd);
 
   _spi->transfer(command);
   while (len--) {
@@ -77,7 +76,7 @@ bool Adafruit_FlashTransport_SPI::readCommand(uint8_t command,
 bool Adafruit_FlashTransport_SPI::writeCommand(uint8_t command,
                                                uint8_t const *data,
                                                uint32_t len) {
-  beginTransaction(_setting_write);
+  beginTransaction(_clock_wr);
 
   _spi->transfer(command);
   while (len--) {
@@ -91,7 +90,7 @@ bool Adafruit_FlashTransport_SPI::writeCommand(uint8_t command,
 
 bool Adafruit_FlashTransport_SPI::eraseCommand(uint8_t command,
                                                uint32_t address) {
-  beginTransaction(_setting_write);
+  beginTransaction(_clock_wr);
 
   uint8_t cmd_with_addr[] = { command, (address >> 16) & 0xFF, (address >> 8) & 0xFF, address & 0xFF };
 
@@ -104,7 +103,7 @@ bool Adafruit_FlashTransport_SPI::eraseCommand(uint8_t command,
 
 bool Adafruit_FlashTransport_SPI::readMemory(uint32_t addr, uint8_t *data,
                                              uint32_t len) {
-  beginTransaction(_setting_read);
+  beginTransaction(_clock_rd);
 
   uint8_t cmd_with_addr[5] = { _cmd_read, (addr >> 16) & 0xFF, (addr >> 8) & 0xFF, addr & 0xFF, 0xFF };
 
@@ -131,7 +130,7 @@ bool Adafruit_FlashTransport_SPI::readMemory(uint32_t addr, uint8_t *data,
 bool Adafruit_FlashTransport_SPI::writeMemory(uint32_t addr,
                                               uint8_t const *data,
                                               uint32_t len) {
-  beginTransaction(_setting_write);
+  beginTransaction(_clock_wr);
 
   uint8_t cmd_with_addr[] = { SFLASH_CMD_PAGE_PROGRAM, (addr >> 16) & 0xFF, (addr >> 8) & 0xFF, addr & 0xFF };
 

--- a/src/spi/Adafruit_FlashTransport_SPI.cpp
+++ b/src/spi/Adafruit_FlashTransport_SPI.cpp
@@ -49,29 +49,29 @@ void Adafruit_FlashTransport_SPI::setClockSpeed(uint32_t clock_hz) {
 }
 
 bool Adafruit_FlashTransport_SPI::runCommand(uint8_t command) {
-  digitalWrite(_ss, LOW);
   _spi->beginTransaction(_setting);
+  digitalWrite(_ss, LOW);
 
   _spi->transfer(command);
 
-  _spi->endTransaction();
   digitalWrite(_ss, HIGH);
+  _spi->endTransaction();
 
   return true;
 }
 
 bool Adafruit_FlashTransport_SPI::readCommand(uint8_t command,
                                               uint8_t *response, uint32_t len) {
-  digitalWrite(_ss, LOW);
   _spi->beginTransaction(_setting);
+  digitalWrite(_ss, LOW);
 
   _spi->transfer(command);
   while (len--) {
     *response++ = _spi->transfer(0xFF);
   }
 
-  _spi->endTransaction();
   digitalWrite(_ss, HIGH);
+  _spi->endTransaction();
 
   return true;
 }
@@ -79,39 +79,40 @@ bool Adafruit_FlashTransport_SPI::readCommand(uint8_t command,
 bool Adafruit_FlashTransport_SPI::writeCommand(uint8_t command,
                                                uint8_t const *data,
                                                uint32_t len) {
-  digitalWrite(_ss, LOW);
   _spi->beginTransaction(_setting);
+  digitalWrite(_ss, LOW);
 
   _spi->transfer(command);
   while (len--) {
     (void)_spi->transfer(*data++);
   }
 
-  _spi->endTransaction();
   digitalWrite(_ss, HIGH);
+  _spi->endTransaction();
 
   return true;
 }
 
 bool Adafruit_FlashTransport_SPI::eraseCommand(uint8_t command,
                                                uint32_t address) {
-  digitalWrite(_ss, LOW);
   _spi->beginTransaction(_setting);
+  digitalWrite(_ss, LOW);
 
   uint8_t cmd_with_addr[] = { command, (address >> 16) & 0xFF, (address >> 8) & 0xFF, address & 0xFF };
 
+  Serial.printf("Erase command = 0x%02X, address = %d\n", command, address);
   _spi->transfer(cmd_with_addr, 4);
 
-  _spi->endTransaction();
   digitalWrite(_ss, HIGH);
+  _spi->endTransaction();
 
   return true;
 }
 
 bool Adafruit_FlashTransport_SPI::readMemory(uint32_t addr, uint8_t *data,
                                              uint32_t len) {
-  digitalWrite(_ss, LOW);
   _spi->beginTransaction(_setting);
+  digitalWrite(_ss, LOW);
 
   uint8_t cmd_with_addr[5] = { _cmd_read, (addr >> 16) & 0xFF, (addr >> 8) & 0xFF, addr & 0xFF, 0xFF };
 
@@ -121,16 +122,17 @@ bool Adafruit_FlashTransport_SPI::readMemory(uint32_t addr, uint8_t *data,
   // Use SPI DMA if available for best performance
 #if defined(ARDUINO_NRF52_ADAFRUIT) && defined(NRF52840_XXAA)
   _spi->transfer(NULL, data, len);
-#elif defined(ARDUINO_ARCH_SAMD) && defined(_ADAFRUIT_ZERODMA_H_)
-  _spi->transfer(NULL, data, len, true);
+//#elif defined(ARDUINO_ARCH_SAMD) && defined(_ADAFRUIT_ZERODMA_H_)
+//  TODO Could only got the 1st SPI read work, 2nd will failed, maybe we didn't clear thing !!!
+//  _spi->transfer(NULL, data, len, true);
 #else
   while (len--) {
     *data++ = _spi->transfer(0xFF);
   }
 #endif
 
-  _spi->endTransaction();
   digitalWrite(_ss, HIGH);
+  _spi->endTransaction();
 
   return true;
 }
@@ -138,8 +140,8 @@ bool Adafruit_FlashTransport_SPI::readMemory(uint32_t addr, uint8_t *data,
 bool Adafruit_FlashTransport_SPI::writeMemory(uint32_t addr,
                                               uint8_t const *data,
                                               uint32_t len) {
-  digitalWrite(_ss, LOW);
   _spi->beginTransaction(_setting);
+  digitalWrite(_ss, LOW);
 
   uint8_t cmd_with_addr[] = { SFLASH_CMD_PAGE_PROGRAM, (addr >> 16) & 0xFF, (addr >> 8) & 0xFF, addr & 0xFF };
 
@@ -148,17 +150,17 @@ bool Adafruit_FlashTransport_SPI::writeMemory(uint32_t addr,
   // Use SPI DMA if available for best performance
 #if defined(ARDUINO_NRF52_ADAFRUIT) && defined(NRF52840_XXAA)
   _spi->transfer(data, NULL, len);
-#elif defined(ARDUINO_ARCH_SAMD) && defined(_ADAFRUIT_ZERODMA_H_) && !defined(ADAFRUIT_FEATHER_M0_EXPRESS)
-  // TODO Out of all M0 boards, Feather M0 seems to have issue with SPI DMA writing, other M0 board seems to be fine
-  _spi->transfer(data, NULL, len, true);
+//#elif defined(ARDUINO_ARCH_SAMD) && defined(_ADAFRUIT_ZERODMA_H_) && !defined(ADAFRUIT_FEATHER_M0_EXPRESS)
+//  // TODO Out of all M0 boards, Feather M0 seems to have issue with SPI DMA writing, other M0 board seems to be fine
+//  _spi->transfer(data, NULL, len, true);
 #else
   while (len--) {
     _spi->transfer(*data++);
   }
 #endif
 
-  _spi->endTransaction();
   digitalWrite(_ss, HIGH);
+  _spi->endTransaction();
 
   return true;
 }

--- a/src/spi/Adafruit_FlashTransport_SPI.h
+++ b/src/spi/Adafruit_FlashTransport_SPI.h
@@ -33,8 +33,8 @@ private:
   uint8_t _ss;
 
   // SAMD21 M0 can write up to 24 Mhz, but can only read reliably with 12 MHz
-  SPISettings _setting_write;
-  SPISettings _setting_read;
+  uint32_t _clock_wr;
+  uint32_t _clock_rd;
 
 public:
   Adafruit_FlashTransport_SPI(uint8_t ss, SPIClass *spiinterface);
@@ -55,8 +55,8 @@ public:
   virtual bool writeMemory(uint32_t addr, uint8_t const *data, uint32_t len);
 
 private:
-  void beginTransaction(SPISettings settings) {
-    _spi->beginTransaction(settings);
+  void beginTransaction(uint32_t clock_hz) {
+    _spi->beginTransaction(SPISettings(clock_hz, MSBFIRST, SPI_MODE0));
     digitalWrite(_ss, LOW);
   }
 

--- a/src/spi/Adafruit_FlashTransport_SPI.h
+++ b/src/spi/Adafruit_FlashTransport_SPI.h
@@ -31,7 +31,10 @@ class Adafruit_FlashTransport_SPI : public Adafruit_FlashTransport {
 private:
   SPIClass *_spi;
   uint8_t _ss;
-  SPISettings _setting;
+
+  // SAMD21 M0 can write up to 24 Mhz, but can only read reliably with 12 MHz
+  SPISettings _setting_write;
+  SPISettings _setting_read;
 
 public:
   Adafruit_FlashTransport_SPI(uint8_t ss, SPIClass *spiinterface);
@@ -41,7 +44,7 @@ public:
 
   virtual bool supportQuadMode(void) { return false; }
 
-  virtual void setClockSpeed(uint32_t clock_hz);
+  virtual void setClockSpeed(uint32_t write_hz, uint32_t read_hz);
 
   virtual bool runCommand(uint8_t command);
   virtual bool readCommand(uint8_t command, uint8_t *response, uint32_t len);
@@ -50,6 +53,17 @@ public:
   virtual bool eraseCommand(uint8_t command, uint32_t address);
   virtual bool readMemory(uint32_t addr, uint8_t *data, uint32_t len);
   virtual bool writeMemory(uint32_t addr, uint8_t const *data, uint32_t len);
+
+private:
+  void beginTransaction(SPISettings settings) {
+    _spi->beginTransaction(settings);
+    digitalWrite(_ss, LOW);
+  }
+
+  void endTransaction(void) {
+    digitalWrite(_ss, HIGH);
+    _spi->endTransaction();
+  }
 };
 
 #endif /* ADAFRUIT_FLASHTRANSPORT_SPI_H_ */


### PR DESCRIPTION
close #28 
- Added support for Fujitsu FRAM 128/256/512 KB : MB85RS1MT/MB85RS2MTA/MB85RS4MT. The support is transparent to user sketch, just make sure the flash transport is declared correctly, the FRAM should be detected automatically.
- Added flash_speedtest example
- Added `void setIndicator(int pin, bool state_on)`
- Improve SPI speed by using DMA transfer for
  - DMA SPI read and write for nrf52
  - DMA SPI write for SAMD M0/M4. There is issue with DMA SPI read on these platform. There will be separated PR/issue later on
-  Allow different clock speed for write and read since SAMD21 can write up to 24 Mhz, but can only read reliably at 12 Mhz with FRAM
- Skip Flash Caching for FRAM

Following is speed test result with this PR on M0/M4/nRF with FRAM and existing GD25Q16C flash device.
```
FRAM with SPI mode (speed in KB/s) 
  - M0 : write (DMA, 24Mhz) = 2400, read (noDMA, 12Mhz) = 490
  - M4 : write (DMA, 24Mhz) = 3000, read (noDMA, 24Mhz) = 1300
  - nRF: write (DMA, 32Mhz) = 3900, read (DMA,   32Mhz) = 3900

GD25Q16C M0 spi, M4 + nRF is QSPI (speed in KB/s)
  - M0 : write (DMA, 24Mhz) = 453, read (noDMA, 24Mhz) = 570
  - M4 : write (DMA, 24Mhz) = 540, read (noDMA, 24Mhz) = 6300
  - nRF: write (DMA, 32Mhz) = 380, read (DMA,   32Mhz) = 7300
```