### PR TITLE
8KB FRAM device support

### DIFF
--- a/src/Adafruit_SPIFlashBase.cpp
+++ b/src/Adafruit_SPIFlashBase.cpp
@@ -35,7 +35,8 @@ static const SPIFlash_Device_t possible_devices[] = {
     W25Q16FW,
     W25Q64JV_IQ,
 
-    // Fujitsu FRAM 128/256/512 KBs
+    // Fujitsu FRAM
+    MB85RS64V,
     MB85RS1MT,
     MB85RS2MTA,
     MB85RS4MT,

--- a/src/flash_devices.h
+++ b/src/flash_devices.h
@@ -116,6 +116,18 @@ typedef struct {
     .single_status_byte = false, .is_fram = false,                             \
   }
 
+// https://www.fujitsu.com/uk/Images/MB85RS64V.pdf
+#define MB85RS64V                                                              \
+  {                                                                            \
+    .total_size = 8*1024, /* 8 KiB */                                          \
+        .start_up_time_us = 5000, .manufacturer_id = 0x04,                     \
+    .memory_type = 0x7F, .capacity = 0x03, .max_clock_speed_mhz = 20,          \
+    .quad_enable_bit_mask = 0x00, .has_sector_protection = false,              \
+    .supports_fast_read = true, .supports_qspi = false,                        \
+    .supports_qspi_writes = true, .write_status_register_split = false,        \
+    .single_status_byte = true, .is_fram = true,                               \
+  }
+
 // https://www.fujitsu.com/uk/Images/MB85RS1MT.pdf
 #define MB85RS1MT                                                              \
   {                                                                            \

--- a/src/flash_devices.h
+++ b/src/flash_devices.h
@@ -119,7 +119,7 @@ typedef struct {
 // https://www.fujitsu.com/uk/Images/MB85RS64V.pdf
 #define MB85RS64V                                                              \
   {                                                                            \
-    .total_size = 8*1024, /* 8 KiB */                                          \
+    .total_size = 8 * 1024, /* 8 KiB */                                        \
         .start_up_time_us = 5000, .manufacturer_id = 0x04,                     \
     .memory_type = 0x7F, .capacity = 0x03, .max_clock_speed_mhz = 20,          \
     .quad_enable_bit_mask = 0x00, .has_sector_protection = false,              \


### PR DESCRIPTION
Although 8KB is too small for FAT FS, it is still worth to add, since the flash API still allow user sketch to use with raw API `readBuffer/writeBuffer()` to read write directly to the flash with great abstaction.

https://github.com/adafruit/Adafruit_SPIFlash/blob/master/src/Adafruit_SPIFlashBase.h#L68

The actual 8KB chip is not tested since I don't have the device on hand yet. However, it should work well since it is pretty much the same with larger part except for slower speed of 20Mhz. Will conduct actual hardware testing later when possible.  