### PR TITLE
fix nrf qspi read/write with misaligned buffer address

### DIFF
--- a/examples/flash_speedtest/flash_speedtest.ino
+++ b/examples/flash_speedtest/flash_speedtest.ino
@@ -31,8 +31,9 @@ Adafruit_SPIFlash flash(&flashTransport);
 
 #define BUFSIZE   4096
 
-uint8_t bufwrite[BUFSIZE];
-uint8_t bufread[BUFSIZE];
+// 4 byte aligned buffer has best result with nRF QSPI
+uint8_t bufwrite[BUFSIZE] __attribute__ ((aligned(4)));
+uint8_t bufread[BUFSIZE] __attribute__ ((aligned(4)));
 
 // the setup function runs once when you press reset or power the board
 void setup()

--- a/src/Adafruit_FlashCache.cpp
+++ b/src/Adafruit_FlashCache.cpp
@@ -113,16 +113,18 @@ bool Adafruit_FlashCache::read(Adafruit_SPIFlash *fl, uint32_t address,
                               (int32_t)(count - dst_off));
 
     // start to cached
-    if (dst_off)
+    if (dst_off) {
       fl->readBuffer(address, buffer, dst_off);
+    }
 
     // cached
     memcpy(buffer + dst_off, _buf + src_off, cache_bytes);
 
     // cached to end
     uint32_t copied = (uint32_t)(dst_off + cache_bytes);
-    if (copied < count)
+    if (copied < count) {
       fl->readBuffer(address + copied, buffer + copied, count - copied);
+    }
   } else {
     fl->readBuffer(address, buffer, count);
   }

--- a/src/Adafruit_FlashCache.h
+++ b/src/Adafruit_FlashCache.h
@@ -33,7 +33,7 @@ class Adafruit_SPIFlash;
 
 class Adafruit_FlashCache {
 private:
-  uint8_t _buf[4096]; // must be sector size
+  uint8_t _buf[4096] __attribute__((aligned(4))); // must be sector size
   uint32_t _addr;
 
 public:


### PR DESCRIPTION
fix #40 , since current working with SPIFlash, I tried to solve as many pending issue as possible.

nRF QSPI native API require buffer must be 4 byte aligned, the built-in flash cache does a good job to handle this so far. However, there could be issue with user that want to use raw API e.g without an fat fs.
This PR is tested thoroughly with feather 52840 express with following testing sketch

```
void setup()
{
  Serial.begin(115200);
  while ( !Serial ) delay(100);   // wait for native usb

  flash.begin();
  
  Serial.println("Adafruit Serial Flash Info example");
  Serial.print("JEDEC ID: "); Serial.println(flash.getJEDECID(), HEX);
  Serial.print("Flash size: "); Serial.println(flash.size());

  flash.eraseSector(0);

  Serial.println("Write odd"); Serial.flush();

  memset(bufwrite, 0x11, sizeof(bufwrite));
  flash.writeBuffer(1, &bufwrite[5], 14);

  Serial.println("Read odd"); Serial.flush();

  flash.readBuffer(1, &bufread[5], 14);
  PRINT_BUFFER(bufread, 32);
}
```