### PR TITLE
enable samd spi dma read

### DIFF
--- a/src/spi/Adafruit_FlashTransport_SPI.cpp
+++ b/src/spi/Adafruit_FlashTransport_SPI.cpp
@@ -116,9 +116,8 @@ bool Adafruit_FlashTransport_SPI::readMemory(uint32_t addr, uint8_t *data,
   // Use SPI DMA if available for best performance
 #if defined(ARDUINO_NRF52_ADAFRUIT) && defined(NRF52840_XXAA)
   _spi->transfer(NULL, data, len);
-//#elif defined(ARDUINO_ARCH_SAMD) && defined(_ADAFRUIT_ZERODMA_H_)
-//  // TODO Could only got the 1st SPI read work, 2nd will failed, maybe we
-//  didn't clear thing !!! _spi->transfer(NULL, data, len, true);
+#elif defined(ARDUINO_ARCH_SAMD) && defined(_ADAFRUIT_ZERODMA_H_)
+  _spi->transfer(NULL, data, len, true);
 #else
   while (len--) {
     *data++ = _spi->transfer(0xFF);


### PR DESCRIPTION
related to #65  need a fix from samd core to work https://github.com/adafruit/ArduinoCore-samd/commit/1e92424a500a8b3fc5be0701bbbab0da167f2cc6

SPI read speed got almost double when using DMA

Following is speed test result with this PR on M0/M4/nRF with FRAM and existing GD25Q16C flash device.

without DMA (speed in KB/s) 

```
- M0 FRAM: read (noDMA, 12Mhz) = 490
- M0 GD25Q16C: read (noDMA, 24Mhz) = 570
- M4 FRAM: read (noDMA, 24Mhz) = 1300
```
with DMA (speed in KB/s) 

```
- M0 FRAM: read (DMA, 12Mhz) = 1200
- M0 GD25Q16C: read (DMA, 24Mhz) = 1200
- M4 FRAM: read (DMA, 24Mhz) = 2950
```