### PR TITLE
Address width updates

### DIFF
--- a/src/Adafruit_FlashTransport.h
+++ b/src/Adafruit_FlashTransport.h
@@ -53,6 +53,9 @@ enum {
   SFLASH_CMD_ERASE_SECTOR = 0x20,
   SFLASH_CMD_ERASE_BLOCK = 0xD8,
   SFLASH_CMD_ERASE_CHIP = 0xC7,
+
+  SFLASH_CMD_4_BYTE_ADDR = 0xB7,
+  SFLASH_CMD_3_BYTE_ADDR = 0xE9,
 };
 
 class Adafruit_FlashTransport {

--- a/src/flash_devices.h
+++ b/src/flash_devices.h
@@ -392,7 +392,7 @@ typedef struct {
     .quad_enable_bit_mask = 0x02, .has_sector_protection = false,              \
     .supports_fast_read = true, .supports_qspi = true,                         \
     .supports_qspi_writes = true, .write_status_register_split = false,        \
-    .single_status_byte = false, .is_fram = false,                              \
+    .single_status_byte = false, .is_fram = false,                             \
   }
 
 // Settings for the Winbond W25Q256JV 32MiB SPI flash.
@@ -405,7 +405,7 @@ typedef struct {
     .quad_enable_bit_mask = 0x02, .has_sector_protection = false,              \
     .supports_fast_read = true, .supports_qspi = true,                         \
     .supports_qspi_writes = true, .write_status_register_split = false,        \
-    .single_status_byte = false, .is_fram = false,                              \
+    .single_status_byte = false, .is_fram = false,                             \
   }
 
 #endif // MICROPY_INCLUDED_ATMEL_SAMD_EXTERNAL_FLASH_DEVICES_H

--- a/src/flash_devices.h
+++ b/src/flash_devices.h
@@ -392,7 +392,7 @@ typedef struct {
     .quad_enable_bit_mask = 0x02, .has_sector_protection = false,              \
     .supports_fast_read = true, .supports_qspi = true,                         \
     .supports_qspi_writes = true, .write_status_register_split = false,        \
-    .single_status_byte = false, is_fram = false,                              \
+    .single_status_byte = false, .is_fram = false,                              \
   }
 
 // Settings for the Winbond W25Q256JV 32MiB SPI flash.
@@ -405,7 +405,7 @@ typedef struct {
     .quad_enable_bit_mask = 0x02, .has_sector_protection = false,              \
     .supports_fast_read = true, .supports_qspi = true,                         \
     .supports_qspi_writes = true, .write_status_register_split = false,        \
-    .single_status_byte = false, is_fram = false,                              \
+    .single_status_byte = false, .is_fram = false,                              \
   }
 
 #endif // MICROPY_INCLUDED_ATMEL_SAMD_EXTERNAL_FLASH_DEVICES_H

--- a/src/spi/Adafruit_FlashTransport_SPI.cpp
+++ b/src/spi/Adafruit_FlashTransport_SPI.cpp
@@ -90,8 +90,7 @@ bool Adafruit_FlashTransport_SPI::writeCommand(uint8_t command,
   return true;
 }
 
-bool Adafruit_FlashTransport_SPI::eraseCommand(uint8_t command,
-                                               uint32_t addr) {
+bool Adafruit_FlashTransport_SPI::eraseCommand(uint8_t command, uint32_t addr) {
   beginTransaction(_clock_wr);
 
   uint8_t cmd_with_addr[5] = {command};
@@ -108,9 +107,11 @@ void Adafruit_FlashTransport_SPI::fillAddress(uint8_t *buf, uint32_t addr) {
   switch (_addr_len) {
   case 4:
     *buf++ = (addr >> 24) & 0xFF;
+    __attribute__((fallthrough));
 
   case 3:
     *buf++ = (addr >> 16) & 0xFF;
+    __attribute__((fallthrough));
 
   case 2:
   default:

--- a/src/spi/Adafruit_FlashTransport_SPI.h
+++ b/src/spi/Adafruit_FlashTransport_SPI.h
@@ -49,7 +49,7 @@ public:
   virtual bool runCommand(uint8_t command);
   virtual bool readCommand(uint8_t command, uint8_t *response, uint32_t len);
   virtual bool writeCommand(uint8_t command, uint8_t const *data, uint32_t len);
-  virtual bool eraseCommand(uint8_t command, uint32_t address);
+  virtual bool eraseCommand(uint8_t command, uint32_t addr);
 
   virtual bool readMemory(uint32_t addr, uint8_t *data, uint32_t len);
   virtual bool writeMemory(uint32_t addr, uint8_t const *data, uint32_t len);


### PR DESCRIPTION
- Add command to enter 4-byte address mode
- Add address length handling to eraseCommand
- Correct buffer size in writeMemory
- Correct flash device is_fram definition
- Replaced spi read loop with _spi->transfer(data, len);
- Removed __attribute__((fallthrough)) due to compiler errors
- Removed #include "wiring_private.h" due to compiler errors