### PR TITLE
Include QSPI only if the board uses it

### DIFF
--- a/src/qspi/Adafruit_FlashTransport_QSPI_NRF.cpp
+++ b/src/qspi/Adafruit_FlashTransport_QSPI_NRF.cpp
@@ -24,7 +24,7 @@
  * THE SOFTWARE.
  */
 
-#ifdef NRF52840_XXAA
+#if defined(NRF52840_XXAA) && defined(EXTERNAL_FLASH_USE_QSPI)
 
 #include "Adafruit_FlashTransport.h"
 #include "nrfx_qspi.h"

--- a/src/qspi/Adafruit_FlashTransport_QSPI_NRF.cpp
+++ b/src/qspi/Adafruit_FlashTransport_QSPI_NRF.cpp
@@ -24,11 +24,14 @@
  * THE SOFTWARE.
  */
 
-#if defined(NRF52840_XXAA) && defined(EXTERNAL_FLASH_USE_QSPI)
+#ifdef NRF52840_XXAA
 
 #include "Adafruit_FlashTransport.h"
 #include "nrfx_qspi.h"
 #include <Arduino.h>
+#include "variant.h"
+
+#ifdef EXTERNAL_FLASH_USE_QSPI
 
 Adafruit_FlashTransport_QSPI::Adafruit_FlashTransport_QSPI(void)
     : Adafruit_FlashTransport_QSPI(PIN_QSPI_SCK, PIN_QSPI_CS, PIN_QSPI_IO0,
@@ -237,4 +240,5 @@ bool Adafruit_FlashTransport_QSPI::writeMemory(uint32_t addr,
   return read_write_memory(false, addr, (uint8_t *)data, len);
 }
 
+#endif
 #endif

--- a/src/qspi/Adafruit_FlashTransport_QSPI_SAMD.cpp
+++ b/src/qspi/Adafruit_FlashTransport_QSPI_SAMD.cpp
@@ -23,11 +23,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#if defined(__SAMD51__) && defined(EXTERNAL_FLASH_USE_QSPI)
+#ifdef __SAMD51__
 
 #include "Adafruit_FlashTransport.h"
 #include "wiring_private.h"
 #include <Arduino.h>
+#include "variant.h"
+
+#ifdef EXTERNAL_FLASH_USE_QSPI
 
 static void _run_instruction(uint8_t command, uint32_t iframe, uint32_t addr,
                              uint8_t *buffer, uint32_t size);
@@ -225,4 +228,5 @@ static void _run_instruction(uint8_t command, uint32_t iframe, uint32_t addr,
   QSPI->INTFLAG.bit.INSTREND = 1;
 }
 
+#endif
 #endif

--- a/src/qspi/Adafruit_FlashTransport_QSPI_SAMD.cpp
+++ b/src/qspi/Adafruit_FlashTransport_QSPI_SAMD.cpp
@@ -23,7 +23,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#ifdef __SAMD51__
+#if defined(__SAMD51__) && defined(EXTERNAL_FLASH_USE_QSPI)
 
 #include "Adafruit_FlashTransport.h"
 #include "wiring_private.h"


### PR DESCRIPTION
Hi,

The library fails to compile if trying to use it in a SAMD51/nRF52840 board with a regular SPI flash chip. It is because QSPI files are included even if the board does not have EXTERNAL_FLASH_USE_QSPI defined -it just checked the architecture.

This small change fixes that, enabling SAMD51/nRF52840 boards without QSPI memories to work with regular SPI.

Best regards,

Enrique