### PR TITLE
Add esp32s2 support

### DIFF
--- a/examples/SdFat_OpenNext/SdFat_OpenNext.ino
+++ b/examples/SdFat_OpenNext/SdFat_OpenNext.ino
@@ -5,18 +5,32 @@
 #include "SdFat.h"
 #include "Adafruit_SPIFlash.h"
 
-// On-board external flash (QSPI or SPI) macros should already
-// defined in your board variant if supported
-// - EXTERNAL_FLASH_USE_QSPI
-// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-#if defined(EXTERNAL_FLASH_USE_QSPI)
-  Adafruit_FlashTransport_QSPI flashTransport;
+// Uncomment to run example with custom SPI and SS e.g with FRAM breakout
+// #define CUSTOM_CS   A5
+// #define CUSTOM_SPI  SPI
 
-#elif defined(EXTERNAL_FLASH_USE_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+
+#elif CONFIG_IDF_TARGET_ESP32S2
+  // ESP32-S2 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  Adafruit_FlashTransport_ESP32 flashTransport;
 
 #else
-  #error No QSPI/SPI flash are defined on your board variant.h !
+  // On-board external flash (QSPI or SPI) macros should already
+  // defined in your board variant if supported
+  // - EXTERNAL_FLASH_USE_QSPI
+  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+  #if defined(EXTERNAL_FLASH_USE_QSPI)
+    Adafruit_FlashTransport_QSPI flashTransport;
+  
+  #elif defined(EXTERNAL_FLASH_USE_SPI)
+    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+  
+  #else
+    #error No QSPI/SPI flash are defined on your board variant.h !
+  #endif
 #endif
 
 Adafruit_SPIFlash flash(&flashTransport);

--- a/examples/SdFat_ReadWrite/SdFat_ReadWrite.ino
+++ b/examples/SdFat_ReadWrite/SdFat_ReadWrite.ino
@@ -21,12 +21,18 @@
 #include "SdFat.h"
 #include "Adafruit_SPIFlash.h"
 
-// Uncomment to run example with FRAM
-// #define FRAM_CS   A5
-// #define FRAM_SPI  SPI
 
-#if defined(FRAM_CS) && defined(FRAM_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(FRAM_CS, FRAM_SPI);
+// Uncomment to run example with custom SPI and SS e.g with FRAM breakout
+// #define CUSTOM_CS   A5
+// #define CUSTOM_SPI  SPI
+
+#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+
+#elif CONFIG_IDF_TARGET_ESP32S2
+  // ESP32-S2 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  Adafruit_FlashTransport_ESP32 flashTransport;
 
 #else
   // On-board external flash (QSPI or SPI) macros should already
@@ -53,7 +59,7 @@ File myFile;
 
 void setup() {
   // Open serial communications and wait for port to open:
-  Serial.begin(9600);
+  Serial.begin(115200);
   while (!Serial) {
     delay(1); // wait for serial port to connect. Needed for native USB port only
   }

--- a/examples/SdFat_format/SdFat_format.ino
+++ b/examples/SdFat_format/SdFat_format.ino
@@ -30,12 +30,17 @@
 // up to 11 characters
 #define DISK_LABEL    "EXT FLASH"
 
-// Uncomment to run example with FRAM
-// #define FRAM_CS   A5
-// #define FRAM_SPI  SPI
+// Uncomment to run example with custom SPI and SS e.g with FRAM breakout
+// #define CUSTOM_CS   A5
+// #define CUSTOM_SPI  SPI
 
-#if defined(FRAM_CS) && defined(FRAM_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(FRAM_CS, FRAM_SPI);
+#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+
+#elif CONFIG_IDF_TARGET_ESP32S2
+  // ESP32-S2 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  Adafruit_FlashTransport_ESP32 flashTransport;
 
 #else
   // On-board external flash (QSPI or SPI) macros should already
@@ -44,10 +49,10 @@
   // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
   #if defined(EXTERNAL_FLASH_USE_QSPI)
     Adafruit_FlashTransport_QSPI flashTransport;
-
+  
   #elif defined(EXTERNAL_FLASH_USE_SPI)
     Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
-
+  
   #else
     #error No QSPI/SPI flash are defined on your board variant.h !
   #endif
@@ -76,7 +81,8 @@ void setup() {
   }
   Serial.print("Flash chip JEDEC ID: 0x"); Serial.println(flash.getJEDECID(), HEX);
 
-  flash.setIndicator(LED_BUILTIN, true);
+  // Uncomment to flash LED while writing to flash
+  // flash.setIndicator(LED_BUILTIN, true);
 
   // Wait for user to send OK to continue.
   Serial.setTimeout(30000);  // Increase timeout to print message less frequently.

--- a/examples/SdFat_print_file/SdFat_print_file.ino
+++ b/examples/SdFat_print_file/SdFat_print_file.ino
@@ -23,18 +23,32 @@
 #include <SdFat.h>
 #include <Adafruit_SPIFlash.h>
 
-// On-board external flash (QSPI or SPI) macros should already
-// defined in your board variant if supported
-// - EXTERNAL_FLASH_USE_QSPI
-// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-#if defined(EXTERNAL_FLASH_USE_QSPI)
-  Adafruit_FlashTransport_QSPI flashTransport;
+// Uncomment to run example with custom SPI and SS e.g with FRAM breakout
+// #define CUSTOM_CS   A5
+// #define CUSTOM_SPI  SPI
 
-#elif defined(EXTERNAL_FLASH_USE_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+
+#elif CONFIG_IDF_TARGET_ESP32S2
+  // ESP32-S2 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  Adafruit_FlashTransport_ESP32 flashTransport;
 
 #else
-  #error No QSPI/SPI flash are defined on your board variant.h !
+  // On-board external flash (QSPI or SPI) macros should already
+  // defined in your board variant if supported
+  // - EXTERNAL_FLASH_USE_QSPI
+  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+  #if defined(EXTERNAL_FLASH_USE_QSPI)
+    Adafruit_FlashTransport_QSPI flashTransport;
+
+  #elif defined(EXTERNAL_FLASH_USE_SPI)
+    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
+  #else
+    #error No QSPI/SPI flash are defined on your board variant.h !
+  #endif
 #endif
 
 Adafruit_SPIFlash flash(&flashTransport);

--- a/examples/flash_info/flash_info.ino
+++ b/examples/flash_info/flash_info.ino
@@ -4,16 +4,16 @@
 #include "SdFat.h"
 #include "Adafruit_SPIFlash.h"
 
-// Uncomment to run example with FRAM
-// #define FRAM_CS   A5
-// #define FRAM_SPI  SPI
+// Uncomment to run example with custom SPI and SS e.g with FRAM breakout
+// #define CUSTOM_CS   A5
+// #define CUSTOM_SPI  SPI
 
-#if defined(FRAM_CS) && defined(FRAM_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(FRAM_CS, FRAM_SPI);
+#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif CONFIG_IDF_TARGET_ESP32S2
-  // ESP32-S2 use same flash device that store code, therefore there is no need to
-  // specify the SPI and SS
+  // ESP32-S2 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
   Adafruit_FlashTransport_ESP32 flashTransport;
 
 #else

--- a/examples/flash_info/flash_info.ino
+++ b/examples/flash_info/flash_info.ino
@@ -11,6 +11,11 @@
 #if defined(FRAM_CS) && defined(FRAM_SPI)
   Adafruit_FlashTransport_SPI flashTransport(FRAM_CS, FRAM_SPI);
 
+#elif CONFIG_IDF_TARGET_ESP32S2
+  // ESP32-S2 use same flash device that store code, therefore there is no need to
+  // specify the SPI and SS
+  Adafruit_FlashTransport_ESP32 flashTransport;
+
 #else
   // On-board external flash (QSPI or SPI) macros should already
   // defined in your board variant if supported
@@ -35,11 +40,12 @@ void setup()
   Serial.begin(115200);
   while ( !Serial ) delay(100);   // wait for native usb
 
-  flash.begin();
-  
   Serial.println("Adafruit Serial Flash Info example");
-  Serial.print("JEDEC ID: "); Serial.println(flash.getJEDECID(), HEX);
-  Serial.print("Flash size: "); Serial.println(flash.size());
+
+  flash.begin();
+
+  Serial.print("JEDEC ID: 0x"); Serial.println(flash.getJEDECID(), HEX);
+  Serial.print("Flash size: "); Serial.print(flash.size() / 1024); Serial.println(" KB");
 }
 
 void loop()

--- a/examples/flash_sector_dump/flash_sector_dump.ino
+++ b/examples/flash_sector_dump/flash_sector_dump.ino
@@ -1,21 +1,34 @@
 // The MIT License (MIT)
 // Copyright (c) 2019 Ha Thach for Adafruit Industries
 
-#include "SdFat.h"
 #include "Adafruit_SPIFlash.h"
 
-// On-board external flash (QSPI or SPI) macros should already
-// defined in your board variant if supported
-// - EXTERNAL_FLASH_USE_QSPI
-// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-#if defined(EXTERNAL_FLASH_USE_QSPI)
-  Adafruit_FlashTransport_QSPI flashTransport;
+// Uncomment to run example with custom SPI and SS e.g with FRAM breakout
+// #define CUSTOM_CS   A5
+// #define CUSTOM_SPI  SPI
 
-#elif defined(EXTERNAL_FLASH_USE_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+
+#elif CONFIG_IDF_TARGET_ESP32S2
+  // ESP32-S2 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  Adafruit_FlashTransport_ESP32 flashTransport;
 
 #else
-  #error No QSPI/SPI flash are defined on your board variant.h !
+  // On-board external flash (QSPI or SPI) macros should already
+  // defined in your board variant if supported
+  // - EXTERNAL_FLASH_USE_QSPI
+  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+  #if defined(EXTERNAL_FLASH_USE_QSPI)
+    Adafruit_FlashTransport_QSPI flashTransport;
+  
+  #elif defined(EXTERNAL_FLASH_USE_SPI)
+    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+  
+  #else
+    #error No QSPI/SPI flash are defined on your board variant.h !
+  #endif
 #endif
 
 Adafruit_SPIFlash flash(&flashTransport);
@@ -35,10 +48,12 @@ void setup()
 
 void dump_sector(uint32_t sector)
 {
-  uint8_t buf[512];
-  flash.readBuffer(sector*512, buf, 512);
+  uint8_t buf[4096];
+  memset(buf, 0xff, sizeof(buf));
+  
+  flash.readBuffer(sector*4096, buf, 4096);
 
-  for(uint32_t row=0; row<32; row++)
+  for(uint32_t row=0; row<sizeof(buf)/16; row++)
   {
     if ( row == 0 ) Serial.print("0");
     if ( row < 16 ) Serial.print("0");
@@ -68,7 +83,7 @@ void loop()
 
   Serial.println(sector); // echo
 
-  if ( sector < flash.size()/512 )
+  if ( sector < flash.size()/4096 )
   {
     dump_sector(sector);
   }else

--- a/src/Adafruit_FlashTransport.h
+++ b/src/Adafruit_FlashTransport.h
@@ -126,6 +126,9 @@ protected:
 
 #include "qspi/Adafruit_FlashTransport_QSPI.h"
 #include "spi/Adafruit_FlashTransport_SPI.h"
+
+#if CONFIG_IDF_TARGET_ESP32S2
 #include "esp32/Adafruit_FlashTransport_ESP32.h"
+#endif
 
 #endif /* ADAFRUIT_FLASHTRANSPORT_H_ */

--- a/src/Adafruit_FlashTransport.h
+++ b/src/Adafruit_FlashTransport.h
@@ -126,5 +126,6 @@ protected:
 
 #include "qspi/Adafruit_FlashTransport_QSPI.h"
 #include "spi/Adafruit_FlashTransport_SPI.h"
+#include "esp32/Adafruit_FlashTransport_ESP32.h"
 
 #endif /* ADAFRUIT_FLASHTRANSPORT_H_ */

--- a/src/Adafruit_FlashTransport.h
+++ b/src/Adafruit_FlashTransport.h
@@ -58,6 +58,13 @@ enum {
   SFLASH_CMD_3_BYTE_ADDR = 0xE9,
 };
 
+/// Constant that is (mostly) true to all external flash devices
+enum {
+  SFLASH_BLOCK_SIZE = 64 * 1024UL,
+  SFLASH_SECTOR_SIZE = 4 * 1024,
+  SFLASH_PAGE_SIZE = 256,
+};
+
 class Adafruit_FlashTransport {
 public:
   virtual void begin(void) = 0;

--- a/src/Adafruit_SPIFlash.cpp
+++ b/src/Adafruit_SPIFlash.cpp
@@ -30,7 +30,7 @@ bool Adafruit_SPIFlash::begin(SPIFlash_Device_t const *flash_devs,
   bool ret = Adafruit_SPIFlashBase::begin(flash_devs, count);
 
   // Use cache if not FRAM
-  if (!_flash_dev->is_fram) {
+  if (_flash_dev && !_flash_dev->is_fram) {
     // new cache object if not already
     if (!_cache) {
       _cache = new Adafruit_FlashCache();

--- a/src/Adafruit_SPIFlashBase.cpp
+++ b/src/Adafruit_SPIFlashBase.cpp
@@ -93,12 +93,12 @@ bool Adafruit_SPIFlashBase::begin(SPIFlash_Device_t const *flash_devs,
   _trans->begin();
 
 #if CONFIG_IDF_TARGET_ESP32S2
-  (void) flash_devs;
-  (void) count;
+  (void)flash_devs;
+  (void)count;
 
   // For ESP32S2 the spi flash is already detected and configured
   // We could skip the initial sequence
-  _flash_dev = ((Adafruit_FlashTransport_ESP32*) _trans)->getFlashDevice();
+  _flash_dev = ((Adafruit_FlashTransport_ESP32 *)_trans)->getFlashDevice();
 
 #else
   //------------- flash detection -------------//

--- a/src/Adafruit_SPIFlashBase.h
+++ b/src/Adafruit_SPIFlashBase.h
@@ -30,13 +30,6 @@
 #include "Adafruit_FlashTransport.h"
 #include "flash_devices.h"
 
-/// Constant that is (mostly) true to all external flash devices
-enum {
-  SFLASH_BLOCK_SIZE = 64 * 1024UL,
-  SFLASH_SECTOR_SIZE = 4 * 1024,
-  SFLASH_PAGE_SIZE = 256,
-};
-
 // An easy to use interface for working with Flash memory.
 //
 // If you are managing allocation of the Flash space yourself, this is the

--- a/src/esp32/Adafruit_FlashTransport_ESP32.cpp
+++ b/src/esp32/Adafruit_FlashTransport_ESP32.cpp
@@ -64,7 +64,9 @@ void Adafruit_FlashTransport_ESP32::setClockSpeed(uint32_t write_hz,
 }
 
 bool Adafruit_FlashTransport_ESP32::runCommand(uint8_t command) {
-  // do nothing
+  // TODO SFLASH_CMD_ERASE_CHIP erase whole partition
+
+  // do nothing, mostly write enable
   return true;
 }
 
@@ -79,74 +81,24 @@ bool Adafruit_FlashTransport_ESP32::readCommand(uint8_t command,
 bool Adafruit_FlashTransport_ESP32::writeCommand(uint8_t command,
                                                uint8_t const *data,
                                                uint32_t len) {
-  // mostly is Write Status, do nothing
+  //  do nothing, mostly is Write Status
   return true;
 }
 
 bool Adafruit_FlashTransport_ESP32::eraseCommand(uint8_t command, uint32_t addr) {
-//  beginTransaction(_clock_wr);
-//
-//  uint8_t cmd_with_addr[5] = {command};
-//  fillAddress(cmd_with_addr + 1, addr);
-//
-//  _spi->transfer(cmd_with_addr, 1 + _addr_len);
-//
-//  endTransaction();
-
-  return true;
+  uint32_t erase_sz = (command == SFLASH_CMD_ERASE_BLOCK) ? SFLASH_BLOCK_SIZE : SFLASH_SECTOR_SIZE;
+  return ESP_OK == esp_partition_erase_range(_partition, addr, erase_sz);
 }
 
 bool Adafruit_FlashTransport_ESP32::readMemory(uint32_t addr, uint8_t *data,
                                              uint32_t len) {
-//  beginTransaction(_clock_rd);
-//
-//  uint8_t cmd_with_addr[6] = {_cmd_read};
-//  fillAddress(cmd_with_addr + 1, addr);
-//
-//  // Fast Read has 1 extra dummy byte
-//  uint8_t const cmd_len =
-//      1 + _addr_len + (SFLASH_CMD_FAST_READ == _cmd_read ? 1 : 0);
-//
-//  _spi->transfer(cmd_with_addr, cmd_len);
-//
-//  // Use SPI DMA if available for best performance
-//#if defined(ARDUINO_NRF52_ADAFRUIT) && defined(NRF52840_XXAA)
-//  _spi->transfer(NULL, data, len);
-//#elif defined(ARDUINO_ARCH_SAMD) && defined(_ADAFRUIT_ZERODMA_H_)
-//  _spi->transfer(NULL, data, len, true);
-//#else
-//  _spi->transfer(data, len);
-//#endif
-//
-//  endTransaction();
-
-  return true;
+  return ESP_OK == esp_partition_read(_partition, addr, data, len);
 }
 
 bool Adafruit_FlashTransport_ESP32::writeMemory(uint32_t addr,
                                               uint8_t const *data,
                                               uint32_t len) {
-//  beginTransaction(_clock_wr);
-//
-//  uint8_t cmd_with_addr[5] = {SFLASH_CMD_PAGE_PROGRAM};
-//  fillAddress(cmd_with_addr + 1, addr);
-//
-//  _spi->transfer(cmd_with_addr, 1 + _addr_len);
-//
-//  // Use SPI DMA if available for best performance
-//#if defined(ARDUINO_NRF52_ADAFRUIT) && defined(NRF52840_XXAA)
-//  _spi->transfer(data, NULL, len);
-//#elif defined(ARDUINO_ARCH_SAMD) && defined(_ADAFRUIT_ZERODMA_H_)
-//  _spi->transfer(data, NULL, len, true);
-//#else
-//  while (len--) {
-//    _spi->transfer(*data++);
-//  }
-//#endif
-
-//  endTransaction();
-
-  return true;
+  return ESP_OK == esp_partition_write(_partition, addr, data, len);
 }
 
 #endif

--- a/src/esp32/Adafruit_FlashTransport_ESP32.cpp
+++ b/src/esp32/Adafruit_FlashTransport_ESP32.cpp
@@ -1,0 +1,152 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 hathach for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "Adafruit_FlashTransport.h"
+
+#if CONFIG_IDF_TARGET_ESP32S2
+
+Adafruit_FlashTransport_ESP32::Adafruit_FlashTransport_ESP32(void)
+{
+  _cmd_read = SFLASH_CMD_READ;
+  _addr_len = 3; // work with most device if not set
+
+  _partition = NULL;
+  memset(&_flash_device, 0, sizeof(_flash_device));
+}
+
+void Adafruit_FlashTransport_ESP32::begin(void) {
+  _partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_FAT, NULL);
+
+  if (!_partition) {
+    log_e("No FAT partition found");
+  }
+}
+
+SPIFlash_Device_t* Adafruit_FlashTransport_ESP32::getFlashDevice(void)
+{
+  if (!_partition) return NULL;
+
+  esp_flash_t const * flash = _partition->flash_chip;
+
+  _flash_device.total_size = flash->size;
+
+  _flash_device.manufacturer_id = (flash->chip_id >> 16);
+  _flash_device.memory_type = (flash->chip_id >> 8) & 0xff;
+  _flash_device.capacity = flash->chip_id & 0xff;
+
+  return &_flash_device;
+}
+
+void Adafruit_FlashTransport_ESP32::setClockSpeed(uint32_t write_hz,
+                                                uint32_t read_hz) {
+  // do nothing, just use current configured clock
+}
+
+bool Adafruit_FlashTransport_ESP32::runCommand(uint8_t command) {
+  // do nothing
+  return true;
+}
+
+bool Adafruit_FlashTransport_ESP32::readCommand(uint8_t command,
+                                              uint8_t *response, uint32_t len) {
+  // mostly is Read STATUS, just fill with 0x0
+  memset(response, 0, len);
+
+  return true;
+}
+
+bool Adafruit_FlashTransport_ESP32::writeCommand(uint8_t command,
+                                               uint8_t const *data,
+                                               uint32_t len) {
+  // mostly is Write Status, do nothing
+  return true;
+}
+
+bool Adafruit_FlashTransport_ESP32::eraseCommand(uint8_t command, uint32_t addr) {
+//  beginTransaction(_clock_wr);
+//
+//  uint8_t cmd_with_addr[5] = {command};
+//  fillAddress(cmd_with_addr + 1, addr);
+//
+//  _spi->transfer(cmd_with_addr, 1 + _addr_len);
+//
+//  endTransaction();
+
+  return true;
+}
+
+bool Adafruit_FlashTransport_ESP32::readMemory(uint32_t addr, uint8_t *data,
+                                             uint32_t len) {
+//  beginTransaction(_clock_rd);
+//
+//  uint8_t cmd_with_addr[6] = {_cmd_read};
+//  fillAddress(cmd_with_addr + 1, addr);
+//
+//  // Fast Read has 1 extra dummy byte
+//  uint8_t const cmd_len =
+//      1 + _addr_len + (SFLASH_CMD_FAST_READ == _cmd_read ? 1 : 0);
+//
+//  _spi->transfer(cmd_with_addr, cmd_len);
+//
+//  // Use SPI DMA if available for best performance
+//#if defined(ARDUINO_NRF52_ADAFRUIT) && defined(NRF52840_XXAA)
+//  _spi->transfer(NULL, data, len);
+//#elif defined(ARDUINO_ARCH_SAMD) && defined(_ADAFRUIT_ZERODMA_H_)
+//  _spi->transfer(NULL, data, len, true);
+//#else
+//  _spi->transfer(data, len);
+//#endif
+//
+//  endTransaction();
+
+  return true;
+}
+
+bool Adafruit_FlashTransport_ESP32::writeMemory(uint32_t addr,
+                                              uint8_t const *data,
+                                              uint32_t len) {
+//  beginTransaction(_clock_wr);
+//
+//  uint8_t cmd_with_addr[5] = {SFLASH_CMD_PAGE_PROGRAM};
+//  fillAddress(cmd_with_addr + 1, addr);
+//
+//  _spi->transfer(cmd_with_addr, 1 + _addr_len);
+//
+//  // Use SPI DMA if available for best performance
+//#if defined(ARDUINO_NRF52_ADAFRUIT) && defined(NRF52840_XXAA)
+//  _spi->transfer(data, NULL, len);
+//#elif defined(ARDUINO_ARCH_SAMD) && defined(_ADAFRUIT_ZERODMA_H_)
+//  _spi->transfer(data, NULL, len, true);
+//#else
+//  while (len--) {
+//    _spi->transfer(*data++);
+//  }
+//#endif
+
+//  endTransaction();
+
+  return true;
+}
+
+#endif

--- a/src/esp32/Adafruit_FlashTransport_ESP32.cpp
+++ b/src/esp32/Adafruit_FlashTransport_ESP32.cpp
@@ -64,8 +64,7 @@ void Adafruit_FlashTransport_ESP32::setClockSpeed(uint32_t write_hz,
 }
 
 bool Adafruit_FlashTransport_ESP32::runCommand(uint8_t command) {
-  // TODO SFLASH_CMD_ERASE_CHIP erase whole partition
-
+  // TODO maybe SFLASH_CMD_ERASE_CHIP should erase whole partition
   // do nothing, mostly write enable
   return true;
 }

--- a/src/esp32/Adafruit_FlashTransport_ESP32.cpp
+++ b/src/esp32/Adafruit_FlashTransport_ESP32.cpp
@@ -26,8 +26,7 @@
 
 #if CONFIG_IDF_TARGET_ESP32S2
 
-Adafruit_FlashTransport_ESP32::Adafruit_FlashTransport_ESP32(void)
-{
+Adafruit_FlashTransport_ESP32::Adafruit_FlashTransport_ESP32(void) {
   _cmd_read = SFLASH_CMD_READ;
   _addr_len = 3; // work with most device if not set
 
@@ -36,18 +35,19 @@ Adafruit_FlashTransport_ESP32::Adafruit_FlashTransport_ESP32(void)
 }
 
 void Adafruit_FlashTransport_ESP32::begin(void) {
-  _partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_FAT, NULL);
+  _partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA,
+                                        ESP_PARTITION_SUBTYPE_DATA_FAT, NULL);
 
   if (!_partition) {
     log_e("No FAT partition found");
   }
 }
 
-SPIFlash_Device_t* Adafruit_FlashTransport_ESP32::getFlashDevice(void)
-{
-  if (!_partition) return NULL;
+SPIFlash_Device_t *Adafruit_FlashTransport_ESP32::getFlashDevice(void) {
+  if (!_partition)
+    return NULL;
 
-  esp_flash_t const * flash = _partition->flash_chip;
+  esp_flash_t const *flash = _partition->flash_chip;
 
   _flash_device.total_size = flash->size;
 
@@ -59,7 +59,7 @@ SPIFlash_Device_t* Adafruit_FlashTransport_ESP32::getFlashDevice(void)
 }
 
 void Adafruit_FlashTransport_ESP32::setClockSpeed(uint32_t write_hz,
-                                                uint32_t read_hz) {
+                                                  uint32_t read_hz) {
   // do nothing, just use current configured clock
 }
 
@@ -70,7 +70,8 @@ bool Adafruit_FlashTransport_ESP32::runCommand(uint8_t command) {
 }
 
 bool Adafruit_FlashTransport_ESP32::readCommand(uint8_t command,
-                                              uint8_t *response, uint32_t len) {
+                                                uint8_t *response,
+                                                uint32_t len) {
   // mostly is Read STATUS, just fill with 0x0
   memset(response, 0, len);
 
@@ -78,25 +79,27 @@ bool Adafruit_FlashTransport_ESP32::readCommand(uint8_t command,
 }
 
 bool Adafruit_FlashTransport_ESP32::writeCommand(uint8_t command,
-                                               uint8_t const *data,
-                                               uint32_t len) {
+                                                 uint8_t const *data,
+                                                 uint32_t len) {
   //  do nothing, mostly is Write Status
   return true;
 }
 
-bool Adafruit_FlashTransport_ESP32::eraseCommand(uint8_t command, uint32_t addr) {
-  uint32_t erase_sz = (command == SFLASH_CMD_ERASE_BLOCK) ? SFLASH_BLOCK_SIZE : SFLASH_SECTOR_SIZE;
+bool Adafruit_FlashTransport_ESP32::eraseCommand(uint8_t command,
+                                                 uint32_t addr) {
+  uint32_t erase_sz = (command == SFLASH_CMD_ERASE_BLOCK) ? SFLASH_BLOCK_SIZE
+                                                          : SFLASH_SECTOR_SIZE;
   return ESP_OK == esp_partition_erase_range(_partition, addr, erase_sz);
 }
 
 bool Adafruit_FlashTransport_ESP32::readMemory(uint32_t addr, uint8_t *data,
-                                             uint32_t len) {
+                                               uint32_t len) {
   return ESP_OK == esp_partition_read(_partition, addr, data, len);
 }
 
 bool Adafruit_FlashTransport_ESP32::writeMemory(uint32_t addr,
-                                              uint8_t const *data,
-                                              uint32_t len) {
+                                                uint8_t const *data,
+                                                uint32_t len) {
   return ESP_OK == esp_partition_write(_partition, addr, data, len);
 }
 

--- a/src/esp32/Adafruit_FlashTransport_ESP32.h
+++ b/src/esp32/Adafruit_FlashTransport_ESP32.h
@@ -1,0 +1,59 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 hathach for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef ADAFRUIT_FLASHTRANSPORT_ESP32_H_
+#define ADAFRUIT_FLASHTRANSPORT_ESP32_H_
+
+#include "Arduino.h"
+#include "SPI.h"
+#include "flash_devices.h"
+
+class Adafruit_FlashTransport_ESP32 : public Adafruit_FlashTransport {
+private:
+    esp_partition_t const * _partition;
+    SPIFlash_Device_t _flash_device;
+
+public:
+  Adafruit_FlashTransport_ESP32(void);
+
+  virtual void begin(void);
+
+  virtual bool supportQuadMode(void) { return false; }
+
+  virtual void setClockSpeed(uint32_t write_hz, uint32_t read_hz);
+
+  virtual bool runCommand(uint8_t command);
+  virtual bool readCommand(uint8_t command, uint8_t *response, uint32_t len);
+  virtual bool writeCommand(uint8_t command, uint8_t const *data, uint32_t len);
+  virtual bool eraseCommand(uint8_t command, uint32_t addr);
+
+  virtual bool readMemory(uint32_t addr, uint8_t *data, uint32_t len);
+  virtual bool writeMemory(uint32_t addr, uint8_t const *data, uint32_t len);
+
+  // Flash device is already detected and configured, get the pointer without
+  // go through initial sequence
+  SPIFlash_Device_t* getFlashDevice(void);
+};
+
+#endif /* ADAFRUIT_FLASHTRANSPORT_ESP32_H_ */

--- a/src/esp32/Adafruit_FlashTransport_ESP32.h
+++ b/src/esp32/Adafruit_FlashTransport_ESP32.h
@@ -31,8 +31,8 @@
 
 class Adafruit_FlashTransport_ESP32 : public Adafruit_FlashTransport {
 private:
-    esp_partition_t const * _partition;
-    SPIFlash_Device_t _flash_device;
+  esp_partition_t const *_partition;
+  SPIFlash_Device_t _flash_device;
 
 public:
   Adafruit_FlashTransport_ESP32(void);
@@ -53,7 +53,7 @@ public:
 
   // Flash device is already detected and configured, get the pointer without
   // go through initial sequence
-  SPIFlash_Device_t* getFlashDevice(void);
+  SPIFlash_Device_t *getFlashDevice(void);
 };
 
 #endif /* ADAFRUIT_FLASHTRANSPORT_ESP32_H_ */


### PR DESCRIPTION
work well enough, all example with SdFat work just fine. Could read/write data to fatfs written by circuipython previously 

Note: Since it requires  https://github.com/adafruit/arduino-esp32/tree/add-custom-board-partition-bootloader for reserving partition definition