### PR TITLE
fix for GD25Q32C descriptor

### DIFF
--- a/src/flash_devices.h
+++ b/src/flash_devices.h
@@ -123,7 +123,7 @@ typedef struct {
         104, /* if we need 120 then we can turn on high performance mode */    \
         .quad_enable_bit_mask = 0x02, .has_sector_protection = false,          \
     .supports_fast_read = true, .supports_qspi = true,                         \
-    .supports_qspi_writes = true, .write_status_register_split = false,        \
+    .supports_qspi_writes = true, .write_status_register_split = true,         \
     .single_status_byte = false, .is_fram = false,                             \
   }
 


### PR DESCRIPTION
GD25Q32C flash memory IC needs split status registers write access :

```
.write_status_register_split = true,
```

This is an excerpt from the GD25Q32C datasheet:

![image](https://user-images.githubusercontent.com/5849637/123692093-13c36f80-d85f-11eb-9ba0-6f18b0cd30ad.png)

<br>

![image](https://user-images.githubusercontent.com/5849637/123692930-16729480-d860-11eb-9b66-9ef08a504d13.png)


<br>
<br>

See also this definition in Adafruit CircuitPython as another reference:
https://github.com/adafruit/circuitpython/blob/6.1.0/supervisor/shared/external_flash/devices.h#L189

