### PR TITLE
support of QSPI transport to operate in 1BIT I/O mode

### DIFF
--- a/src/Adafruit_SPIFlashBase.h
+++ b/src/Adafruit_SPIFlashBase.h
@@ -75,6 +75,8 @@ protected:
   int _ind_pin;
   bool _ind_active;
 
+  void write_status_register(uint8_t *);
+
   void _indicator_on(void) {
     if (_ind_pin >= 0) {
       digitalWrite(_ind_pin, _ind_active ? HIGH : LOW);

--- a/src/qspi/Adafruit_FlashTransport_QSPI_NRF.cpp
+++ b/src/qspi/Adafruit_FlashTransport_QSPI_NRF.cpp
@@ -70,11 +70,19 @@ void Adafruit_FlashTransport_QSPI::begin(void) {
           },
       .irq_priority = 7};
 
+  if (_cmd_read != SFLASH_CMD_QUAD_READ) {
+    qspi_cfg.prot_if.readoc  = NRF_QSPI_READOC_FASTREAD; // 0x0B read command
+    qspi_cfg.prot_if.writeoc = NRF_QSPI_WRITEOC_PP;      // 0x02 write command
+  }
+
   // No callback for blocking API
   nrfx_qspi_init(&qspi_cfg, NULL, NULL);
 }
 
-void Adafruit_FlashTransport_QSPI::end(void) { nrfx_qspi_uninit(); }
+void Adafruit_FlashTransport_QSPI::end(void) {
+  nrfx_qspi_uninit();
+  _cmd_read = SFLASH_CMD_QUAD_READ;
+}
 
 void Adafruit_FlashTransport_QSPI::setClockSpeed(uint32_t clock_hz,
                                                  uint32_t read_hz) {

--- a/src/qspi/Adafruit_FlashTransport_QSPI_SAMD.cpp
+++ b/src/qspi/Adafruit_FlashTransport_QSPI_SAMD.cpp
@@ -141,16 +141,20 @@ bool Adafruit_FlashTransport_QSPI::eraseCommand(uint8_t command,
 
 bool Adafruit_FlashTransport_QSPI::readMemory(uint32_t addr, uint8_t *data,
                                               uint32_t len) {
-  // Command 0x6B 1 line address, 4 line Data
-  // Quad output mode, read memory type
-  uint32_t iframe = QSPI_INSTRFRAME_WIDTH_QUAD_OUTPUT |
+  uint32_t width = (_cmd_read == SFLASH_CMD_QUAD_READ) ?
+                    QSPI_INSTRFRAME_WIDTH_QUAD_OUTPUT  :
+                    QSPI_INSTRFRAME_WIDTH_SINGLE_BIT_SPI;
+
+  // Command 0x6B (or 0x0B) 1 line address, 4 (or 1) line Data
+  // Quad (or single) output mode, read memory type
+  uint32_t iframe = width |
                     QSPI_INSTRFRAME_ADDRLEN_24BITS |
                     QSPI_INSTRFRAME_TFRTYPE_READMEMORY |
                     QSPI_INSTRFRAME_INSTREN | QSPI_INSTRFRAME_ADDREN |
                     QSPI_INSTRFRAME_DATAEN | QSPI_INSTRFRAME_DUMMYLEN(8);
 
   samd_peripherals_disable_and_clear_cache();
-  _run_instruction(SFLASH_CMD_QUAD_READ, iframe, addr, data, len);
+  _run_instruction(_cmd_read, iframe, addr, data, len);
   samd_peripherals_enable_cache();
 
   return true;
@@ -159,14 +163,19 @@ bool Adafruit_FlashTransport_QSPI::readMemory(uint32_t addr, uint8_t *data,
 bool Adafruit_FlashTransport_QSPI::writeMemory(uint32_t addr,
                                                uint8_t const *data,
                                                uint32_t len) {
-  uint32_t iframe =
-      QSPI_INSTRFRAME_WIDTH_QUAD_OUTPUT | QSPI_INSTRFRAME_ADDRLEN_24BITS |
+  uint32_t width = (_cmd_read == SFLASH_CMD_QUAD_READ) ?
+                    QSPI_INSTRFRAME_WIDTH_QUAD_OUTPUT  :
+                    QSPI_INSTRFRAME_WIDTH_SINGLE_BIT_SPI;
+
+  uint32_t iframe = width | QSPI_INSTRFRAME_ADDRLEN_24BITS |
       QSPI_INSTRFRAME_TFRTYPE_WRITEMEMORY | QSPI_INSTRFRAME_INSTREN |
       QSPI_INSTRFRAME_ADDREN | QSPI_INSTRFRAME_DATAEN;
 
+  uint8_t cmd = (_cmd_read == SFLASH_CMD_QUAD_READ) ?
+                 SFLASH_CMD_QUAD_PAGE_PROGRAM : SFLASH_CMD_PAGE_PROGRAM;
+
   samd_peripherals_disable_and_clear_cache();
-  _run_instruction(SFLASH_CMD_QUAD_PAGE_PROGRAM, iframe, addr, (uint8_t *)data,
-                   len);
+  _run_instruction(cmd, iframe, addr, (uint8_t *)data, len);
   samd_peripherals_enable_cache();
 
   return true;


### PR DESCRIPTION
Fix for https://github.com/adafruit/Adafruit_SPIFlash/issues/104