### PR TITLE
remove debug prints from rp2040

### DIFF
--- a/src/rp2040/Adafruit_FlashTransport_RP2040.cpp
+++ b/src/rp2040/Adafruit_FlashTransport_RP2040.cpp
@@ -78,12 +78,6 @@ void Adafruit_FlashTransport_RP2040::begin(void) {
   }
   _flash_dev.total_size = _size;
 
-  Serial.print("Start = 0x");
-  Serial.println(_start_addr, HEX);
-
-  Serial.print("Size = ");
-  Serial.println(_size);
-
   // Read the RDID register to get the flash capacity.
   uint8_t const cmd[] = {
       0x9f,


### PR DESCRIPTION
Thanks for sharing the great code.

I am trying to use your code to use the Raspberry Pi Pico Flash as a Fat file system via USB.
So I tried to run the sample program SdFat_format.ino.
But the program hangs with debugging display.
I checked and it seems that the Serial.print() output by the library is the cause.
<img width="1020" alt="スクリーンショット 2022-03-15 23 20 02" src="https://user-images.githubusercontent.com/11240403/158399657-3ec90c85-273e-4b59-be25-5d907f14c8e5.png">

I removed the debug print code to try and the problem went away.
<img width="1020" alt="スクリーンショット 2022-03-15 23 25 58" src="https://user-images.githubusercontent.com/11240403/158400023-b31604b0-c1b3-40aa-a17a-d72aa83121f6.png">

This Serial.print() seems to be unnecessary in the production code, so could you please remove it?

Thanks.