### PR TITLE
prevent unintended interruptions

### DIFF
--- a/src/rp2040/Adafruit_FlashTransport_RP2040.cpp
+++ b/src/rp2040/Adafruit_FlashTransport_RP2040.cpp
@@ -86,7 +86,9 @@ void Adafruit_FlashTransport_RP2040::begin(void) {
       0,
   };
   uint8_t data[4];
+  fl_lock();
   flash_do_cmd(cmd, data, 5);
+  fl_unlock();
 
   uint8_t *jedec_ids = data + 1;
 


### PR DESCRIPTION
Thank you for quickly incorporating my corrections(#112) .

As hathach said, the real hang cause is not print. The cause is lack of exclusions.
I have added locks before and after flash_do_cmd() as well as other flash api.

If I add locks, it will work correctly even if there is a debug print.
<img width="1020" alt="スクリーンショット 2022-03-16 0 33 43" src="https://user-images.githubusercontent.com/11240403/158413927-a5f935c3-a0a9-4d9c-83ed-4732ac29f7e7.png">

Please merge if it is OK.

Thank you.