### PR TITLE
Support Sdfat v2

### DIFF
--- a/examples/SdFat_Flash_and_SDcard/SdFat_Flash_and_SDcard.ino
+++ b/examples/SdFat_Flash_and_SDcard/SdFat_Flash_and_SDcard.ino
@@ -6,39 +6,12 @@
 // Flash and SD card (if present) and display information about the QSPI flash.
 //
 
+#include <SPI.h>
 #include <SdFat.h>
 #include <Adafruit_SPIFlash.h>
 
-#if defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
-
-#elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
-
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
-
-#else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
-
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
-
-  #else
-    #error No QSPI/SPI flash are defined on your board variant.h !
-  #endif
-#endif
+// for flashTransport definition
+#include "flash_config.h"
 
 Adafruit_SPIFlash onboardFlash(&flashTransport);
 SdFat onboardSdCard;

--- a/examples/SdFat_Flash_and_SDcard/flash_config.h
+++ b/examples/SdFat_Flash_and_SDcard/flash_config.h
@@ -33,8 +33,8 @@
 Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-// ESP32 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
+// ESP32 use same flash device that store code for file system.
+// SPIFlash will parse partition.cvs to detect FATFS partition to use
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)

--- a/examples/SdFat_Flash_and_SDcard/flash_config.h
+++ b/examples/SdFat_Flash_and_SDcard/flash_config.h
@@ -1,0 +1,67 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef FLASH_CONFIG_H_
+#define FLASH_CONFIG_H_
+
+// Un-comment to run example with custom SPI and SS e.g with FRAM breakout
+// #define CUSTOM_CS   A5
+// #define CUSTOM_SPI  SPI
+
+#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+
+#elif defined(ARDUINO_ARCH_ESP32)
+  // ESP32 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  Adafruit_FlashTransport_ESP32 flashTransport;
+
+#elif defined(ARDUINO_ARCH_RP2040)
+  // RP2040 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
+  Adafruit_FlashTransport_RP2040 flashTransport;
+
+  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+  // If start_address and size are both 0, value that match filesystem setting in
+  // 'Tools->Flash Size' menu selection will be used
+
+#else
+  // On-board external flash (QSPI or SPI) macros should already
+  // defined in your board variant if supported
+  // - EXTERNAL_FLASH_USE_QSPI
+  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+  #if defined(EXTERNAL_FLASH_USE_QSPI)
+    Adafruit_FlashTransport_QSPI flashTransport;
+
+  #elif defined(EXTERNAL_FLASH_USE_SPI)
+    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
+  #else
+    #error No (Q)SPI flash are defined for your board !
+  #endif
+#endif
+
+
+#endif

--- a/examples/SdFat_Flash_and_SDcard/flash_config.h
+++ b/examples/SdFat_Flash_and_SDcard/flash_config.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
@@ -30,38 +30,39 @@
 // #define CUSTOM_SPI  SPI
 
 #if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
+// ESP32 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
+// RP2040 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+// Use default (no-args) constructor to be compatible with CircuitPython
+// partition scheme
+Adafruit_FlashTransport_RP2040 flashTransport;
 
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
+// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+// If start_address and size are both 0, value that match filesystem setting in
+// 'Tools->Flash Size' menu selection will be used
 
 #else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+Adafruit_FlashTransport_QSPI flashTransport;
 
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS,
+                                           EXTERNAL_FLASH_USE_SPI);
 
-  #else
-    #error No (Q)SPI flash are defined for your board !
-  #endif
+#else
+#error No (Q)SPI flash are defined for your board !
 #endif
-
+#endif
 
 #endif

--- a/examples/SdFat_Flash_and_SDcard/flash_config.h
+++ b/examples/SdFat_Flash_and_SDcard/flash_config.h
@@ -38,15 +38,19 @@ Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-// RP2040 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
-// Use default (no-args) constructor to be compatible with CircuitPython
-// partition scheme
+// RP2040 use same flash device that store code for file system. Therefore we
+// only need to specify start address and size (no need SPI or SS)
+//   Adafruit_FlashTransport_RP2040(start_address, size)
+// If start = 0, size = 0 (default), values that match file system setting in
+// 'Tools->Flash Size' menu selection will be used.
 Adafruit_FlashTransport_RP2040 flashTransport;
 
-// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-// If start_address and size are both 0, value that match filesystem setting in
-// 'Tools->Flash Size' menu selection will be used
+// To be compatible with CircuitPython partition scheme (start_address = 1 MB,
+// size = total flash - 1 MB) use const value (CPY_START_ADDR, CPY_SIZE).
+// Un-comment following line:
+// Adafruit_FlashTransport_RP2040
+//     flashTransport(Adafruit_FlashTransport_RP2040::CPY_START_ADDR,
+//                    Adafruit_FlashTransport_RP2040::CPY_SIZE);
 
 #else
 // On-board external flash (QSPI or SPI) macros should already

--- a/examples/SdFat_OpenNext/SdFat_OpenNext.ino
+++ b/examples/SdFat_OpenNext/SdFat_OpenNext.ino
@@ -5,43 +5,8 @@
 #include "SdFat.h"
 #include "Adafruit_SPIFlash.h"
 
-// Uncomment to run example with custom SPI and SS e.g with FRAM breakout
-// #define CUSTOM_CS   A5
-// #define CUSTOM_SPI  SPI
-
-#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
-
-#elif defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
-
-#elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
-
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
-
-#else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
-  
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
-  
-  #else
-    #error No QSPI/SPI flash are defined on your board variant.h !
-  #endif
-#endif
+// for flashTransport definition
+#include "flash_config.h"
 
 Adafruit_SPIFlash flash(&flashTransport);
 

--- a/examples/SdFat_OpenNext/SdFat_OpenNext.ino
+++ b/examples/SdFat_OpenNext/SdFat_OpenNext.ino
@@ -46,10 +46,10 @@
 Adafruit_SPIFlash flash(&flashTransport);
 
 // file system object from SdFat
-FatFileSystem fatfs;
+FatVolume fatfs;
 
-FatFile root;
-FatFile file;
+File32 root;
+File32 file;
 
 //------------------------------------------------------------------------------
 void setup() {
@@ -63,7 +63,7 @@ void setup() {
   
   // Wait for USB Serial 
   while (!Serial) {
-    SysCall::yield();
+    yield();
   }
   
   if (!root.open("/")) {

--- a/examples/SdFat_OpenNext/flash_config.h
+++ b/examples/SdFat_OpenNext/flash_config.h
@@ -33,8 +33,8 @@
 Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-// ESP32 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
+// ESP32 use same flash device that store code for file system.
+// SPIFlash will parse partition.cvs to detect FATFS partition to use
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)

--- a/examples/SdFat_OpenNext/flash_config.h
+++ b/examples/SdFat_OpenNext/flash_config.h
@@ -1,0 +1,67 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef FLASH_CONFIG_H_
+#define FLASH_CONFIG_H_
+
+// Un-comment to run example with custom SPI and SS e.g with FRAM breakout
+// #define CUSTOM_CS   A5
+// #define CUSTOM_SPI  SPI
+
+#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+
+#elif defined(ARDUINO_ARCH_ESP32)
+  // ESP32 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  Adafruit_FlashTransport_ESP32 flashTransport;
+
+#elif defined(ARDUINO_ARCH_RP2040)
+  // RP2040 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
+  Adafruit_FlashTransport_RP2040 flashTransport;
+
+  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+  // If start_address and size are both 0, value that match filesystem setting in
+  // 'Tools->Flash Size' menu selection will be used
+
+#else
+  // On-board external flash (QSPI or SPI) macros should already
+  // defined in your board variant if supported
+  // - EXTERNAL_FLASH_USE_QSPI
+  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+  #if defined(EXTERNAL_FLASH_USE_QSPI)
+    Adafruit_FlashTransport_QSPI flashTransport;
+
+  #elif defined(EXTERNAL_FLASH_USE_SPI)
+    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
+  #else
+    #error No (Q)SPI flash are defined for your board !
+  #endif
+#endif
+
+
+#endif

--- a/examples/SdFat_OpenNext/flash_config.h
+++ b/examples/SdFat_OpenNext/flash_config.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
@@ -30,38 +30,39 @@
 // #define CUSTOM_SPI  SPI
 
 #if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
+// ESP32 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
+// RP2040 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+// Use default (no-args) constructor to be compatible with CircuitPython
+// partition scheme
+Adafruit_FlashTransport_RP2040 flashTransport;
 
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
+// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+// If start_address and size are both 0, value that match filesystem setting in
+// 'Tools->Flash Size' menu selection will be used
 
 #else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+Adafruit_FlashTransport_QSPI flashTransport;
 
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS,
+                                           EXTERNAL_FLASH_USE_SPI);
 
-  #else
-    #error No (Q)SPI flash are defined for your board !
-  #endif
+#else
+#error No (Q)SPI flash are defined for your board !
 #endif
-
+#endif
 
 #endif

--- a/examples/SdFat_OpenNext/flash_config.h
+++ b/examples/SdFat_OpenNext/flash_config.h
@@ -38,15 +38,19 @@ Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-// RP2040 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
-// Use default (no-args) constructor to be compatible with CircuitPython
-// partition scheme
+// RP2040 use same flash device that store code for file system. Therefore we
+// only need to specify start address and size (no need SPI or SS)
+//   Adafruit_FlashTransport_RP2040(start_address, size)
+// If start = 0, size = 0 (default), values that match file system setting in
+// 'Tools->Flash Size' menu selection will be used.
 Adafruit_FlashTransport_RP2040 flashTransport;
 
-// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-// If start_address and size are both 0, value that match filesystem setting in
-// 'Tools->Flash Size' menu selection will be used
+// To be compatible with CircuitPython partition scheme (start_address = 1 MB,
+// size = total flash - 1 MB) use const value (CPY_START_ADDR, CPY_SIZE).
+// Un-comment following line:
+// Adafruit_FlashTransport_RP2040
+//     flashTransport(Adafruit_FlashTransport_RP2040::CPY_START_ADDR,
+//                    Adafruit_FlashTransport_RP2040::CPY_SIZE);
 
 #else
 // On-board external flash (QSPI or SPI) macros should already

--- a/examples/SdFat_ReadWrite/SdFat_ReadWrite.ino
+++ b/examples/SdFat_ReadWrite/SdFat_ReadWrite.ino
@@ -63,26 +63,62 @@
 Adafruit_SPIFlash flash(&flashTransport);
 
 // file system object from SdFat
-FatFileSystem fatfs;
+FatVolume fatfs;
 
-File myFile;
+File32 myFile;
+
+void dump_sector(uint32_t sector)
+{
+  uint8_t buf[4096];
+  memset(buf, 0xff, sizeof(buf));
+
+  flash.readBuffer(sector*4096, buf, 4096);
+
+  for(uint32_t row=0; row<sizeof(buf)/16; row++)
+  {
+    if ( row == 0 ) Serial.print("0");
+    if ( row < 16 ) Serial.print("0");
+    Serial.print(row*16, HEX);
+    Serial.print(" : ");
+//    PRINTF("%03X :", row*16);
+
+    for(uint32_t col=0; col<16; col++)
+    {
+      uint8_t val = buf[row*16 + col];
+
+      if ( val < 16 ) Serial.print("0");
+      Serial.print(val, HEX);
+      Serial.print(" ");
+//      PRINTF("%02X ");
+    }
+
+    Serial.println();
+//    PRINTF("\n");
+  }
+}
 
 void setup() {
   // Open serial communications and wait for port to open:
   Serial.begin(115200);
   while (!Serial) {
-    delay(1); // wait for serial port to connect. Needed for native USB port only
+    delay(10); // wait for serial port to connect. Needed for native USB port only
   }
 
-  Serial.print("Initializing Filesystem on external flash...");
+  Serial.println("Initializing Filesystem on external flash...");
   
   // Init external flash
   flash.begin();
 
+  dump_sector(0);
+
   // Open file system on the flash
   if ( !fatfs.begin(&flash) ) {
     Serial.println("Error: filesystem is not existed. Please try SdFat_format example to make one.");
-    while(1) yield();
+    while(1)
+    {
+      yield();
+      delay(1);
+    }
   }
 
   Serial.println("initialization done.");

--- a/examples/SdFat_ReadWrite/SdFat_ReadWrite.ino
+++ b/examples/SdFat_ReadWrite/SdFat_ReadWrite.ino
@@ -28,38 +28,7 @@ Adafruit_SPIFlash flash(&flashTransport);
 
 // file system object from SdFat
 FatVolume fatfs;
-
 File32 myFile;
-
-void dump_sector(uint32_t sector)
-{
-  uint8_t buf[4096];
-  memset(buf, 0xff, sizeof(buf));
-
-  flash.readBuffer(sector*4096, buf, 4096);
-
-  for(uint32_t row=0; row<sizeof(buf)/16; row++)
-  {
-    if ( row == 0 ) Serial.print("0");
-    if ( row < 16 ) Serial.print("0");
-    Serial.print(row*16, HEX);
-    Serial.print(" : ");
-//    PRINTF("%03X :", row*16);
-
-    for(uint32_t col=0; col<16; col++)
-    {
-      uint8_t val = buf[row*16 + col];
-
-      if ( val < 16 ) Serial.print("0");
-      Serial.print(val, HEX);
-      Serial.print(" ");
-//      PRINTF("%02X ");
-    }
-
-    Serial.println();
-//    PRINTF("\n");
-  }
-}
 
 void setup() {
   // Open serial communications and wait for port to open:
@@ -72,8 +41,6 @@ void setup() {
   
   // Init external flash
   flash.begin();
-
-  dump_sector(0);
 
   // Open file system on the flash
   if ( !fatfs.begin(&flash) ) {

--- a/examples/SdFat_ReadWrite/SdFat_ReadWrite.ino
+++ b/examples/SdFat_ReadWrite/SdFat_ReadWrite.ino
@@ -21,44 +21,8 @@
 #include "SdFat.h"
 #include "Adafruit_SPIFlash.h"
 
-
-// Uncomment to run example with custom SPI and SS e.g with FRAM breakout
-// #define CUSTOM_CS   A5
-// #define CUSTOM_SPI  SPI
-
-#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
-
-#elif defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
-
-#elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
-
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
-
-#else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
-
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
-
-  #else
-    #error No QSPI/SPI flash are defined on your board variant.h !
-  #endif
-#endif
+// for flashTransport definition
+#include "flash_config.h"
 
 Adafruit_SPIFlash flash(&flashTransport);
 

--- a/examples/SdFat_ReadWrite/flash_config.h
+++ b/examples/SdFat_ReadWrite/flash_config.h
@@ -33,8 +33,8 @@
 Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-// ESP32 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
+// ESP32 use same flash device that store code for file system.
+// SPIFlash will parse partition.cvs to detect FATFS partition to use
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)

--- a/examples/SdFat_ReadWrite/flash_config.h
+++ b/examples/SdFat_ReadWrite/flash_config.h
@@ -1,0 +1,67 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef FLASH_CONFIG_H_
+#define FLASH_CONFIG_H_
+
+// Un-comment to run example with custom SPI and SS e.g with FRAM breakout
+// #define CUSTOM_CS   A5
+// #define CUSTOM_SPI  SPI
+
+#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+
+#elif defined(ARDUINO_ARCH_ESP32)
+  // ESP32 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  Adafruit_FlashTransport_ESP32 flashTransport;
+
+#elif defined(ARDUINO_ARCH_RP2040)
+  // RP2040 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
+  Adafruit_FlashTransport_RP2040 flashTransport;
+
+  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+  // If start_address and size are both 0, value that match filesystem setting in
+  // 'Tools->Flash Size' menu selection will be used
+
+#else
+  // On-board external flash (QSPI or SPI) macros should already
+  // defined in your board variant if supported
+  // - EXTERNAL_FLASH_USE_QSPI
+  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+  #if defined(EXTERNAL_FLASH_USE_QSPI)
+    Adafruit_FlashTransport_QSPI flashTransport;
+
+  #elif defined(EXTERNAL_FLASH_USE_SPI)
+    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
+  #else
+    #error No (Q)SPI flash are defined for your board !
+  #endif
+#endif
+
+
+#endif

--- a/examples/SdFat_ReadWrite/flash_config.h
+++ b/examples/SdFat_ReadWrite/flash_config.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
@@ -30,38 +30,39 @@
 // #define CUSTOM_SPI  SPI
 
 #if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
+// ESP32 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
+// RP2040 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+// Use default (no-args) constructor to be compatible with CircuitPython
+// partition scheme
+Adafruit_FlashTransport_RP2040 flashTransport;
 
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
+// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+// If start_address and size are both 0, value that match filesystem setting in
+// 'Tools->Flash Size' menu selection will be used
 
 #else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+Adafruit_FlashTransport_QSPI flashTransport;
 
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS,
+                                           EXTERNAL_FLASH_USE_SPI);
 
-  #else
-    #error No (Q)SPI flash are defined for your board !
-  #endif
+#else
+#error No (Q)SPI flash are defined for your board !
 #endif
-
+#endif
 
 #endif

--- a/examples/SdFat_ReadWrite/flash_config.h
+++ b/examples/SdFat_ReadWrite/flash_config.h
@@ -38,15 +38,19 @@ Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-// RP2040 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
-// Use default (no-args) constructor to be compatible with CircuitPython
-// partition scheme
+// RP2040 use same flash device that store code for file system. Therefore we
+// only need to specify start address and size (no need SPI or SS)
+//   Adafruit_FlashTransport_RP2040(start_address, size)
+// If start = 0, size = 0 (default), values that match file system setting in
+// 'Tools->Flash Size' menu selection will be used.
 Adafruit_FlashTransport_RP2040 flashTransport;
 
-// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-// If start_address and size are both 0, value that match filesystem setting in
-// 'Tools->Flash Size' menu selection will be used
+// To be compatible with CircuitPython partition scheme (start_address = 1 MB,
+// size = total flash - 1 MB) use const value (CPY_START_ADDR, CPY_SIZE).
+// Un-comment following line:
+// Adafruit_FlashTransport_RP2040
+//     flashTransport(Adafruit_FlashTransport_RP2040::CPY_START_ADDR,
+//                    Adafruit_FlashTransport_RP2040::CPY_SIZE);
 
 #else
 // On-board external flash (QSPI or SPI) macros should already

--- a/examples/SdFat_circuitpython/SdFat_circuitpython.ino
+++ b/examples/SdFat_circuitpython/SdFat_circuitpython.ino
@@ -61,7 +61,7 @@
 Adafruit_SPIFlash flash(&flashTransport);
 
 // file system object from SdFat
-FatFileSystem fatfs;
+FatVolume fatfs;
 
 
 void setup() {
@@ -90,7 +90,7 @@ void setup() {
 
   // Check if a boot.py exists and print it out.
   if (fatfs.exists("boot.py")) {
-    File bootPy = fatfs.open("boot.py", FILE_READ);
+    File32 bootPy = fatfs.open("boot.py", FILE_READ);
     Serial.println("Printing boot.py...");
     while (bootPy.available()) {
       char c = bootPy.read();
@@ -104,7 +104,7 @@ void setup() {
 
   // Check if a main.py exists and print it out:
   if (fatfs.exists("code.py")) {
-    File mainPy = fatfs.open("code.py", FILE_READ);
+    File32 mainPy = fatfs.open("code.py", FILE_READ);
     Serial.println("Printing code.py...");
     while (mainPy.available()) {
       char c = mainPy.read();
@@ -119,7 +119,7 @@ void setup() {
   // Create or append to a data.txt file and add a new line
   // to the end of it.  CircuitPython code can later open and
   // see this file too!
-  File data = fatfs.open("data.txt", FILE_WRITE);
+  File32 data = fatfs.open("data.txt", FILE_WRITE);
   if (data) {
     // Write a new line to the file:
     data.println("Hello CircuitPython from Arduino!");

--- a/examples/SdFat_circuitpython/SdFat_circuitpython.ino
+++ b/examples/SdFat_circuitpython/SdFat_circuitpython.ino
@@ -27,42 +27,13 @@
 #include <SdFat.h>
 #include <Adafruit_SPIFlash.h>
 
-#if defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
-
-#elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
-
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
-
-#else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
-
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
-
-  #else
-    #error No QSPI/SPI flash are defined on your board variant.h !
-  #endif
-#endif
+// for flashTransport definition
+#include "flash_config.h"
 
 Adafruit_SPIFlash flash(&flashTransport);
 
 // file system object from SdFat
 FatVolume fatfs;
-
 
 void setup() {
   // Initialize serial port and wait for it to open before continuing.

--- a/examples/SdFat_circuitpython/flash_config.h
+++ b/examples/SdFat_circuitpython/flash_config.h
@@ -33,8 +33,8 @@
 Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-// ESP32 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
+// ESP32 use same flash device that store code for file system.
+// SPIFlash will parse partition.cvs to detect FATFS partition to use
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)

--- a/examples/SdFat_circuitpython/flash_config.h
+++ b/examples/SdFat_circuitpython/flash_config.h
@@ -1,0 +1,67 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef FLASH_CONFIG_H_
+#define FLASH_CONFIG_H_
+
+// Un-comment to run example with custom SPI and SS e.g with FRAM breakout
+// #define CUSTOM_CS   A5
+// #define CUSTOM_SPI  SPI
+
+#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+
+#elif defined(ARDUINO_ARCH_ESP32)
+  // ESP32 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  Adafruit_FlashTransport_ESP32 flashTransport;
+
+#elif defined(ARDUINO_ARCH_RP2040)
+  // RP2040 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
+  Adafruit_FlashTransport_RP2040 flashTransport;
+
+  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+  // If start_address and size are both 0, value that match filesystem setting in
+  // 'Tools->Flash Size' menu selection will be used
+
+#else
+  // On-board external flash (QSPI or SPI) macros should already
+  // defined in your board variant if supported
+  // - EXTERNAL_FLASH_USE_QSPI
+  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+  #if defined(EXTERNAL_FLASH_USE_QSPI)
+    Adafruit_FlashTransport_QSPI flashTransport;
+
+  #elif defined(EXTERNAL_FLASH_USE_SPI)
+    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
+  #else
+    #error No (Q)SPI flash are defined for your board !
+  #endif
+#endif
+
+
+#endif

--- a/examples/SdFat_circuitpython/flash_config.h
+++ b/examples/SdFat_circuitpython/flash_config.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
@@ -30,38 +30,39 @@
 // #define CUSTOM_SPI  SPI
 
 #if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
+// ESP32 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
+// RP2040 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+// Use default (no-args) constructor to be compatible with CircuitPython
+// partition scheme
+Adafruit_FlashTransport_RP2040 flashTransport;
 
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
+// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+// If start_address and size are both 0, value that match filesystem setting in
+// 'Tools->Flash Size' menu selection will be used
 
 #else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+Adafruit_FlashTransport_QSPI flashTransport;
 
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS,
+                                           EXTERNAL_FLASH_USE_SPI);
 
-  #else
-    #error No (Q)SPI flash are defined for your board !
-  #endif
+#else
+#error No (Q)SPI flash are defined for your board !
 #endif
-
+#endif
 
 #endif

--- a/examples/SdFat_circuitpython/flash_config.h
+++ b/examples/SdFat_circuitpython/flash_config.h
@@ -38,15 +38,19 @@ Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-// RP2040 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
-// Use default (no-args) constructor to be compatible with CircuitPython
-// partition scheme
+// RP2040 use same flash device that store code for file system. Therefore we
+// only need to specify start address and size (no need SPI or SS)
+//   Adafruit_FlashTransport_RP2040(start_address, size)
+// If start = 0, size = 0 (default), values that match file system setting in
+// 'Tools->Flash Size' menu selection will be used.
 Adafruit_FlashTransport_RP2040 flashTransport;
 
-// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-// If start_address and size are both 0, value that match filesystem setting in
-// 'Tools->Flash Size' menu selection will be used
+// To be compatible with CircuitPython partition scheme (start_address = 1 MB,
+// size = total flash - 1 MB) use const value (CPY_START_ADDR, CPY_SIZE).
+// Un-comment following line:
+// Adafruit_FlashTransport_RP2040
+//     flashTransport(Adafruit_FlashTransport_RP2040::CPY_START_ADDR,
+//                    Adafruit_FlashTransport_RP2040::CPY_SIZE);
 
 #else
 // On-board external flash (QSPI or SPI) macros should already

--- a/examples/SdFat_circuitpython_backupFiles/SdFat_circuitpython_backupFiles.ino
+++ b/examples/SdFat_circuitpython_backupFiles/SdFat_circuitpython_backupFiles.ino
@@ -50,7 +50,7 @@
 Adafruit_SPIFlash flash(&flashTransport);
 
 // file system object from SdFat
-FatFileSystem fatfs;
+FatVolume fatfs;
 
 
 #define NEOPIN         40       // neopixel pin
@@ -118,8 +118,8 @@ boolean moveFile(const char *file, const char *dest) {
 
   pixel.setPixelColor(0, pixel.Color(100,100,0)); pixel.show();
 
-  File source = fatfs.open(file, FILE_READ);
-  File backup = fatfs.open(dest, FILE_WRITE);
+  File32 source = fatfs.open(file, FILE_READ);
+  File32 backup = fatfs.open(dest, FILE_WRITE);
   Serial.println("Making backup!");
   Serial.println("\n---------------------\n");
 
@@ -143,7 +143,7 @@ boolean moveFile(const char *file, const char *dest) {
     }
     buffer[toread] = 0;      
     Serial.print(buffer);
-    if (backup.write(buffer, toread) != toread) {
+    if ( (int) backup.write(buffer, toread) != toread) {
         Serial.println("Error, couldn't write data to backup file!");
         error(6);
     }

--- a/examples/SdFat_circuitpython_backupFiles/SdFat_circuitpython_backupFiles.ino
+++ b/examples/SdFat_circuitpython_backupFiles/SdFat_circuitpython_backupFiles.ino
@@ -16,42 +16,13 @@
 #include <Adafruit_SPIFlash.h>
 #include <Adafruit_NeoPixel.h>
 
-#if defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
-
-#elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
-
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
-
-#else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
-
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
-
-  #else
-    #error No QSPI/SPI flash are defined on your board variant.h !
-  #endif
-#endif
+// for flashTransport definition
+#include "flash_config.h"
 
 Adafruit_SPIFlash flash(&flashTransport);
 
 // file system object from SdFat
 FatVolume fatfs;
-
 
 #define NEOPIN         40       // neopixel pin
 #define BUFFERSIZ      200

--- a/examples/SdFat_circuitpython_backupFiles/flash_config.h
+++ b/examples/SdFat_circuitpython_backupFiles/flash_config.h
@@ -33,8 +33,8 @@
 Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-// ESP32 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
+// ESP32 use same flash device that store code for file system.
+// SPIFlash will parse partition.cvs to detect FATFS partition to use
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)

--- a/examples/SdFat_circuitpython_backupFiles/flash_config.h
+++ b/examples/SdFat_circuitpython_backupFiles/flash_config.h
@@ -1,0 +1,67 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef FLASH_CONFIG_H_
+#define FLASH_CONFIG_H_
+
+// Un-comment to run example with custom SPI and SS e.g with FRAM breakout
+// #define CUSTOM_CS   A5
+// #define CUSTOM_SPI  SPI
+
+#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+
+#elif defined(ARDUINO_ARCH_ESP32)
+  // ESP32 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  Adafruit_FlashTransport_ESP32 flashTransport;
+
+#elif defined(ARDUINO_ARCH_RP2040)
+  // RP2040 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
+  Adafruit_FlashTransport_RP2040 flashTransport;
+
+  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+  // If start_address and size are both 0, value that match filesystem setting in
+  // 'Tools->Flash Size' menu selection will be used
+
+#else
+  // On-board external flash (QSPI or SPI) macros should already
+  // defined in your board variant if supported
+  // - EXTERNAL_FLASH_USE_QSPI
+  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+  #if defined(EXTERNAL_FLASH_USE_QSPI)
+    Adafruit_FlashTransport_QSPI flashTransport;
+
+  #elif defined(EXTERNAL_FLASH_USE_SPI)
+    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
+  #else
+    #error No (Q)SPI flash are defined for your board !
+  #endif
+#endif
+
+
+#endif

--- a/examples/SdFat_circuitpython_backupFiles/flash_config.h
+++ b/examples/SdFat_circuitpython_backupFiles/flash_config.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
@@ -30,38 +30,39 @@
 // #define CUSTOM_SPI  SPI
 
 #if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
+// ESP32 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
+// RP2040 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+// Use default (no-args) constructor to be compatible with CircuitPython
+// partition scheme
+Adafruit_FlashTransport_RP2040 flashTransport;
 
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
+// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+// If start_address and size are both 0, value that match filesystem setting in
+// 'Tools->Flash Size' menu selection will be used
 
 #else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+Adafruit_FlashTransport_QSPI flashTransport;
 
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS,
+                                           EXTERNAL_FLASH_USE_SPI);
 
-  #else
-    #error No (Q)SPI flash are defined for your board !
-  #endif
+#else
+#error No (Q)SPI flash are defined for your board !
 #endif
-
+#endif
 
 #endif

--- a/examples/SdFat_circuitpython_backupFiles/flash_config.h
+++ b/examples/SdFat_circuitpython_backupFiles/flash_config.h
@@ -38,15 +38,19 @@ Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-// RP2040 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
-// Use default (no-args) constructor to be compatible with CircuitPython
-// partition scheme
+// RP2040 use same flash device that store code for file system. Therefore we
+// only need to specify start address and size (no need SPI or SS)
+//   Adafruit_FlashTransport_RP2040(start_address, size)
+// If start = 0, size = 0 (default), values that match file system setting in
+// 'Tools->Flash Size' menu selection will be used.
 Adafruit_FlashTransport_RP2040 flashTransport;
 
-// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-// If start_address and size are both 0, value that match filesystem setting in
-// 'Tools->Flash Size' menu selection will be used
+// To be compatible with CircuitPython partition scheme (start_address = 1 MB,
+// size = total flash - 1 MB) use const value (CPY_START_ADDR, CPY_SIZE).
+// Un-comment following line:
+// Adafruit_FlashTransport_RP2040
+//     flashTransport(Adafruit_FlashTransport_RP2040::CPY_START_ADDR,
+//                    Adafruit_FlashTransport_RP2040::CPY_SIZE);
 
 #else
 // On-board external flash (QSPI or SPI) macros should already

--- a/examples/SdFat_datalogging/SdFat_datalogging.ino
+++ b/examples/SdFat_datalogging/SdFat_datalogging.ino
@@ -19,36 +19,8 @@
 #include <SdFat.h>
 #include <Adafruit_SPIFlash.h>
 
-#if defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
-
-#elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
-
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
-
-#else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
-
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
-
-  #else
-    #error No QSPI/SPI flash are defined on your board variant.h !
-  #endif
-#endif
+// for flashTransport definition
+#include "flash_config.h"
 
 Adafruit_SPIFlash flash(&flashTransport);
 

--- a/examples/SdFat_datalogging/SdFat_datalogging.ino
+++ b/examples/SdFat_datalogging/SdFat_datalogging.ino
@@ -53,7 +53,7 @@
 Adafruit_SPIFlash flash(&flashTransport);
 
 // file system object from SdFat
-FatFileSystem fatfs;
+FatVolume fatfs;
 
 // Configuration for the datalogging file:
 #define FILE_NAME      "data.csv"
@@ -89,7 +89,7 @@ void setup() {
 void loop() {
   // Open the datalogging file for writing.  The FILE_WRITE mode will open
   // the file for appending, i.e. it will add new data to the end of the file.
-  File dataFile = fatfs.open(FILE_NAME, FILE_WRITE);
+  File32 dataFile = fatfs.open(FILE_NAME, FILE_WRITE);
   // Check that the file opened successfully and write a line to it.
   if (dataFile) {
     // Take a new data reading from a sensor, etc.  For this example just

--- a/examples/SdFat_datalogging/flash_config.h
+++ b/examples/SdFat_datalogging/flash_config.h
@@ -33,8 +33,8 @@
 Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-// ESP32 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
+// ESP32 use same flash device that store code for file system.
+// SPIFlash will parse partition.cvs to detect FATFS partition to use
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)

--- a/examples/SdFat_datalogging/flash_config.h
+++ b/examples/SdFat_datalogging/flash_config.h
@@ -1,0 +1,67 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef FLASH_CONFIG_H_
+#define FLASH_CONFIG_H_
+
+// Un-comment to run example with custom SPI and SS e.g with FRAM breakout
+// #define CUSTOM_CS   A5
+// #define CUSTOM_SPI  SPI
+
+#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+
+#elif defined(ARDUINO_ARCH_ESP32)
+  // ESP32 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  Adafruit_FlashTransport_ESP32 flashTransport;
+
+#elif defined(ARDUINO_ARCH_RP2040)
+  // RP2040 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
+  Adafruit_FlashTransport_RP2040 flashTransport;
+
+  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+  // If start_address and size are both 0, value that match filesystem setting in
+  // 'Tools->Flash Size' menu selection will be used
+
+#else
+  // On-board external flash (QSPI or SPI) macros should already
+  // defined in your board variant if supported
+  // - EXTERNAL_FLASH_USE_QSPI
+  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+  #if defined(EXTERNAL_FLASH_USE_QSPI)
+    Adafruit_FlashTransport_QSPI flashTransport;
+
+  #elif defined(EXTERNAL_FLASH_USE_SPI)
+    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
+  #else
+    #error No (Q)SPI flash are defined for your board !
+  #endif
+#endif
+
+
+#endif

--- a/examples/SdFat_datalogging/flash_config.h
+++ b/examples/SdFat_datalogging/flash_config.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
@@ -30,38 +30,39 @@
 // #define CUSTOM_SPI  SPI
 
 #if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
+// ESP32 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
+// RP2040 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+// Use default (no-args) constructor to be compatible with CircuitPython
+// partition scheme
+Adafruit_FlashTransport_RP2040 flashTransport;
 
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
+// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+// If start_address and size are both 0, value that match filesystem setting in
+// 'Tools->Flash Size' menu selection will be used
 
 #else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+Adafruit_FlashTransport_QSPI flashTransport;
 
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS,
+                                           EXTERNAL_FLASH_USE_SPI);
 
-  #else
-    #error No (Q)SPI flash are defined for your board !
-  #endif
+#else
+#error No (Q)SPI flash are defined for your board !
 #endif
-
+#endif
 
 #endif

--- a/examples/SdFat_datalogging/flash_config.h
+++ b/examples/SdFat_datalogging/flash_config.h
@@ -38,15 +38,19 @@ Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-// RP2040 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
-// Use default (no-args) constructor to be compatible with CircuitPython
-// partition scheme
+// RP2040 use same flash device that store code for file system. Therefore we
+// only need to specify start address and size (no need SPI or SS)
+//   Adafruit_FlashTransport_RP2040(start_address, size)
+// If start = 0, size = 0 (default), values that match file system setting in
+// 'Tools->Flash Size' menu selection will be used.
 Adafruit_FlashTransport_RP2040 flashTransport;
 
-// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-// If start_address and size are both 0, value that match filesystem setting in
-// 'Tools->Flash Size' menu selection will be used
+// To be compatible with CircuitPython partition scheme (start_address = 1 MB,
+// size = total flash - 1 MB) use const value (CPY_START_ADDR, CPY_SIZE).
+// Un-comment following line:
+// Adafruit_FlashTransport_RP2040
+//     flashTransport(Adafruit_FlashTransport_RP2040::CPY_START_ADDR,
+//                    Adafruit_FlashTransport_RP2040::CPY_SIZE);
 
 #else
 // On-board external flash (QSPI or SPI) macros should already

--- a/examples/SdFat_format/SdFat_format.ino
+++ b/examples/SdFat_format/SdFat_format.ino
@@ -54,7 +54,9 @@ void setup() {
     Serial.println("Error, failed to initialize flash chip!");
     while(1) yield();
   }
+
   Serial.print("Flash chip JEDEC ID: 0x"); Serial.println(flash.getJEDECID(), HEX);
+  Serial.print("Flash size: "); Serial.print(flash.size() / 1024); Serial.println(" KB");
 
   // Uncomment to flash LED while writing to flash
   // flash.setIndicator(LED_BUILTIN, true);

--- a/examples/SdFat_format/SdFat_format.ino
+++ b/examples/SdFat_format/SdFat_format.ino
@@ -30,43 +30,8 @@
 // up to 11 characters
 #define DISK_LABEL    "EXT FLASH"
 
-// Uncomment to run example with custom SPI and SS e.g with FRAM breakout
-// #define CUSTOM_CS   A5
-// #define CUSTOM_SPI  SPI
-
-#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
-
-#elif defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
-
-#elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
-
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
-
-#else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
-  
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
-  
-  #else
-    #error No QSPI/SPI flash are defined on your board variant.h !
-  #endif
-#endif
+// for flashTransport definition
+#include "flash_config.h"
 
 Adafruit_SPIFlash flash(&flashTransport);
 

--- a/examples/SdFat_format/SdFat_format.ino
+++ b/examples/SdFat_format/SdFat_format.ino
@@ -71,7 +71,7 @@
 Adafruit_SPIFlash flash(&flashTransport);
 
 // file system object from SdFat
-FatFileSystem fatfs;
+FatVolume fatfs;
 
 // Elm Cham's fatfs objects
 FATFS elmchamFatfs;
@@ -107,7 +107,7 @@ void setup() {
   Serial.println("Creating and formatting FAT filesystem (this takes ~60 seconds)...");
 
   // Make filesystem.
-  FRESULT r = f_mkfs("", FM_FAT | FM_SFD, 0, workbuf, sizeof(workbuf));
+  FRESULT r = f_mkfs("", FM_FAT, 0, workbuf, sizeof(workbuf));
   if (r != FR_OK) {
     Serial.print("Error, f_mkfs failed with error code: "); Serial.println(r, DEC);
     while(1) yield();

--- a/examples/SdFat_format/flash_config.h
+++ b/examples/SdFat_format/flash_config.h
@@ -33,8 +33,8 @@
 Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-// ESP32 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
+// ESP32 use same flash device that store code for file system.
+// SPIFlash will parse partition.cvs to detect FATFS partition to use
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)

--- a/examples/SdFat_format/flash_config.h
+++ b/examples/SdFat_format/flash_config.h
@@ -1,0 +1,67 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef FLASH_CONFIG_H_
+#define FLASH_CONFIG_H_
+
+// Un-comment to run example with custom SPI and SS e.g with FRAM breakout
+// #define CUSTOM_CS   A5
+// #define CUSTOM_SPI  SPI
+
+#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+
+#elif defined(ARDUINO_ARCH_ESP32)
+  // ESP32 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  Adafruit_FlashTransport_ESP32 flashTransport;
+
+#elif defined(ARDUINO_ARCH_RP2040)
+  // RP2040 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
+  Adafruit_FlashTransport_RP2040 flashTransport;
+
+  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+  // If start_address and size are both 0, value that match filesystem setting in
+  // 'Tools->Flash Size' menu selection will be used
+
+#else
+  // On-board external flash (QSPI or SPI) macros should already
+  // defined in your board variant if supported
+  // - EXTERNAL_FLASH_USE_QSPI
+  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+  #if defined(EXTERNAL_FLASH_USE_QSPI)
+    Adafruit_FlashTransport_QSPI flashTransport;
+
+  #elif defined(EXTERNAL_FLASH_USE_SPI)
+    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
+  #else
+    #error No (Q)SPI flash are defined for your board !
+  #endif
+#endif
+
+
+#endif

--- a/examples/SdFat_format/flash_config.h
+++ b/examples/SdFat_format/flash_config.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
@@ -30,38 +30,39 @@
 // #define CUSTOM_SPI  SPI
 
 #if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
+// ESP32 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
+// RP2040 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+// Use default (no-args) constructor to be compatible with CircuitPython
+// partition scheme
+Adafruit_FlashTransport_RP2040 flashTransport;
 
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
+// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+// If start_address and size are both 0, value that match filesystem setting in
+// 'Tools->Flash Size' menu selection will be used
 
 #else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+Adafruit_FlashTransport_QSPI flashTransport;
 
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS,
+                                           EXTERNAL_FLASH_USE_SPI);
 
-  #else
-    #error No (Q)SPI flash are defined for your board !
-  #endif
+#else
+#error No (Q)SPI flash are defined for your board !
 #endif
-
+#endif
 
 #endif

--- a/examples/SdFat_format/flash_config.h
+++ b/examples/SdFat_format/flash_config.h
@@ -38,15 +38,19 @@ Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-// RP2040 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
-// Use default (no-args) constructor to be compatible with CircuitPython
-// partition scheme
+// RP2040 use same flash device that store code for file system. Therefore we
+// only need to specify start address and size (no need SPI or SS)
+//   Adafruit_FlashTransport_RP2040(start_address, size)
+// If start = 0, size = 0 (default), values that match file system setting in
+// 'Tools->Flash Size' menu selection will be used.
 Adafruit_FlashTransport_RP2040 flashTransport;
 
-// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-// If start_address and size are both 0, value that match filesystem setting in
-// 'Tools->Flash Size' menu selection will be used
+// To be compatible with CircuitPython partition scheme (start_address = 1 MB,
+// size = total flash - 1 MB) use const value (CPY_START_ADDR, CPY_SIZE).
+// Un-comment following line:
+// Adafruit_FlashTransport_RP2040
+//     flashTransport(Adafruit_FlashTransport_RP2040::CPY_START_ADDR,
+//                    Adafruit_FlashTransport_RP2040::CPY_SIZE);
 
 #else
 // On-board external flash (QSPI or SPI) macros should already

--- a/examples/SdFat_full_usage/SdFat_full_usage.ino
+++ b/examples/SdFat_full_usage/SdFat_full_usage.ino
@@ -26,36 +26,8 @@
 #include <SdFat.h>
 #include <Adafruit_SPIFlash.h>
 
-#if defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
-
-#elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
-
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
-
-#else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
-
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
-
-  #else
-    #error No QSPI/SPI flash are defined on your board variant.h !
-  #endif
-#endif
+// for flashTransport definition
+#include "flash_config.h"
 
 Adafruit_SPIFlash flash(&flashTransport);
 

--- a/examples/SdFat_full_usage/SdFat_full_usage.ino
+++ b/examples/SdFat_full_usage/SdFat_full_usage.ino
@@ -60,7 +60,7 @@
 Adafruit_SPIFlash flash(&flashTransport);
 
 // file system object from SdFat
-FatFileSystem fatfs;
+FatVolume fatfs;
 
 void setup() {
   // Initialize serial port and wait for it to open before continuing.
@@ -136,7 +136,7 @@ void setup() {
   // write to the file.  This will create the file if it doesn't exist,
   // otherwise it will open the file and start appending new data to the
   // end of it.
-  File writeFile = fatfs.open("/test/test.txt", FILE_WRITE);
+  File32 writeFile = fatfs.open("/test/test.txt", FILE_WRITE);
   if (!writeFile) {
     Serial.println("Error, failed to open test.txt for writing!");
     while(1) yield();
@@ -154,7 +154,7 @@ void setup() {
   Serial.println("Wrote to file /test/test.txt!");
 
   // Now open the same file but for reading.
-  File readFile = fatfs.open("/test/test.txt", FILE_READ);
+  File32 readFile = fatfs.open("/test/test.txt", FILE_READ);
   if (!readFile) {
     Serial.println("Error, failed to open test.txt for reading!");
     while(1) yield();
@@ -173,7 +173,9 @@ void setup() {
   Serial.print("Available data to read in test.txt: "); Serial.println(readFile.available(), DEC);
 
   // And a few other interesting attributes of a file:
-  Serial.print("File name: "); Serial.println(readFile.name());
+  char readName[64];
+  readFile.getName(readName, sizeof(readName));
+  Serial.print("File name: "); Serial.println(readName);
   Serial.print("Is file a directory? "); Serial.println(readFile.isDirectory() ? "Yes" : "No");
 
   // You can seek around inside the file relative to the start of the file.
@@ -196,7 +198,7 @@ void setup() {
 
   // You can open a directory to list all the children (files and directories).
   // Just like the SD library the File type represents either a file or directory.
-  File testDir = fatfs.open("/test");
+  File32 testDir = fatfs.open("/test");
   if (!testDir) {
     Serial.println("Error, failed to open test directory!");
     while(1) yield();
@@ -206,7 +208,7 @@ void setup() {
     while(1) yield();
   }
   Serial.println("Listing children of directory /test:");
-  File child = testDir.openNextFile();
+  File32 child = testDir.openNextFile();
   while (child) {
     char filename[64];
     child.getName(filename, sizeof(filename));
@@ -231,7 +233,7 @@ void setup() {
 
   // Delete a file with the remove command.  For example create a test2.txt file
   // inside /test/foo and then delete it.
-  File test2File = fatfs.open("/test/foo/test2.txt", FILE_WRITE);
+  File32 test2File = fatfs.open("/test/foo/test2.txt", FILE_WRITE);
   test2File.close();
   Serial.println("Deleting /test/foo/test2.txt...");
   if (!fatfs.remove("/test/foo/test2.txt")) {

--- a/examples/SdFat_full_usage/flash_config.h
+++ b/examples/SdFat_full_usage/flash_config.h
@@ -33,8 +33,8 @@
 Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-// ESP32 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
+// ESP32 use same flash device that store code for file system.
+// SPIFlash will parse partition.cvs to detect FATFS partition to use
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)

--- a/examples/SdFat_full_usage/flash_config.h
+++ b/examples/SdFat_full_usage/flash_config.h
@@ -1,0 +1,67 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef FLASH_CONFIG_H_
+#define FLASH_CONFIG_H_
+
+// Un-comment to run example with custom SPI and SS e.g with FRAM breakout
+// #define CUSTOM_CS   A5
+// #define CUSTOM_SPI  SPI
+
+#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+
+#elif defined(ARDUINO_ARCH_ESP32)
+  // ESP32 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  Adafruit_FlashTransport_ESP32 flashTransport;
+
+#elif defined(ARDUINO_ARCH_RP2040)
+  // RP2040 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
+  Adafruit_FlashTransport_RP2040 flashTransport;
+
+  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+  // If start_address and size are both 0, value that match filesystem setting in
+  // 'Tools->Flash Size' menu selection will be used
+
+#else
+  // On-board external flash (QSPI or SPI) macros should already
+  // defined in your board variant if supported
+  // - EXTERNAL_FLASH_USE_QSPI
+  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+  #if defined(EXTERNAL_FLASH_USE_QSPI)
+    Adafruit_FlashTransport_QSPI flashTransport;
+
+  #elif defined(EXTERNAL_FLASH_USE_SPI)
+    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
+  #else
+    #error No (Q)SPI flash are defined for your board !
+  #endif
+#endif
+
+
+#endif

--- a/examples/SdFat_full_usage/flash_config.h
+++ b/examples/SdFat_full_usage/flash_config.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
@@ -30,38 +30,39 @@
 // #define CUSTOM_SPI  SPI
 
 #if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
+// ESP32 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
+// RP2040 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+// Use default (no-args) constructor to be compatible with CircuitPython
+// partition scheme
+Adafruit_FlashTransport_RP2040 flashTransport;
 
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
+// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+// If start_address and size are both 0, value that match filesystem setting in
+// 'Tools->Flash Size' menu selection will be used
 
 #else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+Adafruit_FlashTransport_QSPI flashTransport;
 
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS,
+                                           EXTERNAL_FLASH_USE_SPI);
 
-  #else
-    #error No (Q)SPI flash are defined for your board !
-  #endif
+#else
+#error No (Q)SPI flash are defined for your board !
 #endif
-
+#endif
 
 #endif

--- a/examples/SdFat_full_usage/flash_config.h
+++ b/examples/SdFat_full_usage/flash_config.h
@@ -38,15 +38,19 @@ Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-// RP2040 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
-// Use default (no-args) constructor to be compatible with CircuitPython
-// partition scheme
+// RP2040 use same flash device that store code for file system. Therefore we
+// only need to specify start address and size (no need SPI or SS)
+//   Adafruit_FlashTransport_RP2040(start_address, size)
+// If start = 0, size = 0 (default), values that match file system setting in
+// 'Tools->Flash Size' menu selection will be used.
 Adafruit_FlashTransport_RP2040 flashTransport;
 
-// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-// If start_address and size are both 0, value that match filesystem setting in
-// 'Tools->Flash Size' menu selection will be used
+// To be compatible with CircuitPython partition scheme (start_address = 1 MB,
+// size = total flash - 1 MB) use const value (CPY_START_ADDR, CPY_SIZE).
+// Un-comment following line:
+// Adafruit_FlashTransport_RP2040
+//     flashTransport(Adafruit_FlashTransport_RP2040::CPY_START_ADDR,
+//                    Adafruit_FlashTransport_RP2040::CPY_SIZE);
 
 #else
 // On-board external flash (QSPI or SPI) macros should already

--- a/examples/SdFat_print_file/SdFat_print_file.ino
+++ b/examples/SdFat_print_file/SdFat_print_file.ino
@@ -32,7 +32,7 @@ Adafruit_SPIFlash flash(&flashTransport);
 FatVolume fatfs;
 
 // Configuration for the file to open and read:
-#define FILE_NAME      "data.csv"
+#define FILE_NAME      "test2.txt"
 
 void setup() {
   // Initialize serial port and wait for it to open before continuing.
@@ -74,7 +74,9 @@ void setup() {
     }
   }
   else {
-    Serial.println("Failed to open data file! Does it exist?");
+    Serial.print("Failed to open file \"");
+    Serial.print(FILE_NAME);
+    Serial.print("\" !! Does it exist?");
   }
 }
 

--- a/examples/SdFat_print_file/SdFat_print_file.ino
+++ b/examples/SdFat_print_file/SdFat_print_file.ino
@@ -23,43 +23,8 @@
 #include <SdFat.h>
 #include <Adafruit_SPIFlash.h>
 
-// Uncomment to run example with custom SPI and SS e.g with FRAM breakout
-// #define CUSTOM_CS   A5
-// #define CUSTOM_SPI  SPI
-
-#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
-
-#elif defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
-
-#elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
-
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
-
-#else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
-
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
-
-  #else
-    #error No QSPI/SPI flash are defined on your board variant.h !
-  #endif
-#endif
+// for flashTransport definition
+#include "flash_config.h"
 
 Adafruit_SPIFlash flash(&flashTransport);
 

--- a/examples/SdFat_print_file/SdFat_print_file.ino
+++ b/examples/SdFat_print_file/SdFat_print_file.ino
@@ -64,7 +64,7 @@
 Adafruit_SPIFlash flash(&flashTransport);
 
 // file system object from SdFat
-FatFileSystem fatfs;
+FatVolume fatfs;
 
 // Configuration for the file to open and read:
 #define FILE_NAME      "data.csv"
@@ -95,7 +95,7 @@ void setup() {
 
   // Open the file for reading and check that it was successfully opened.
   // The FILE_READ mode will open the file for reading.
-  File dataFile = fatfs.open(FILE_NAME, FILE_READ);
+  File32 dataFile = fatfs.open(FILE_NAME, FILE_READ);
   if (dataFile) {
     // File was opened, now print out data character by character until at the
     // end of the file.

--- a/examples/SdFat_print_file/flash_config.h
+++ b/examples/SdFat_print_file/flash_config.h
@@ -33,8 +33,8 @@
 Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-// ESP32 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
+// ESP32 use same flash device that store code for file system.
+// SPIFlash will parse partition.cvs to detect FATFS partition to use
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)

--- a/examples/SdFat_print_file/flash_config.h
+++ b/examples/SdFat_print_file/flash_config.h
@@ -1,0 +1,67 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef FLASH_CONFIG_H_
+#define FLASH_CONFIG_H_
+
+// Un-comment to run example with custom SPI and SS e.g with FRAM breakout
+// #define CUSTOM_CS   A5
+// #define CUSTOM_SPI  SPI
+
+#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+
+#elif defined(ARDUINO_ARCH_ESP32)
+  // ESP32 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  Adafruit_FlashTransport_ESP32 flashTransport;
+
+#elif defined(ARDUINO_ARCH_RP2040)
+  // RP2040 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
+  Adafruit_FlashTransport_RP2040 flashTransport;
+
+  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+  // If start_address and size are both 0, value that match filesystem setting in
+  // 'Tools->Flash Size' menu selection will be used
+
+#else
+  // On-board external flash (QSPI or SPI) macros should already
+  // defined in your board variant if supported
+  // - EXTERNAL_FLASH_USE_QSPI
+  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+  #if defined(EXTERNAL_FLASH_USE_QSPI)
+    Adafruit_FlashTransport_QSPI flashTransport;
+
+  #elif defined(EXTERNAL_FLASH_USE_SPI)
+    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
+  #else
+    #error No (Q)SPI flash are defined for your board !
+  #endif
+#endif
+
+
+#endif

--- a/examples/SdFat_print_file/flash_config.h
+++ b/examples/SdFat_print_file/flash_config.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
@@ -30,38 +30,39 @@
 // #define CUSTOM_SPI  SPI
 
 #if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
+// ESP32 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
+// RP2040 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+// Use default (no-args) constructor to be compatible with CircuitPython
+// partition scheme
+Adafruit_FlashTransport_RP2040 flashTransport;
 
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
+// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+// If start_address and size are both 0, value that match filesystem setting in
+// 'Tools->Flash Size' menu selection will be used
 
 #else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+Adafruit_FlashTransport_QSPI flashTransport;
 
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS,
+                                           EXTERNAL_FLASH_USE_SPI);
 
-  #else
-    #error No (Q)SPI flash are defined for your board !
-  #endif
+#else
+#error No (Q)SPI flash are defined for your board !
 #endif
-
+#endif
 
 #endif

--- a/examples/SdFat_print_file/flash_config.h
+++ b/examples/SdFat_print_file/flash_config.h
@@ -38,15 +38,19 @@ Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-// RP2040 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
-// Use default (no-args) constructor to be compatible with CircuitPython
-// partition scheme
+// RP2040 use same flash device that store code for file system. Therefore we
+// only need to specify start address and size (no need SPI or SS)
+//   Adafruit_FlashTransport_RP2040(start_address, size)
+// If start = 0, size = 0 (default), values that match file system setting in
+// 'Tools->Flash Size' menu selection will be used.
 Adafruit_FlashTransport_RP2040 flashTransport;
 
-// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-// If start_address and size are both 0, value that match filesystem setting in
-// 'Tools->Flash Size' menu selection will be used
+// To be compatible with CircuitPython partition scheme (start_address = 1 MB,
+// size = total flash - 1 MB) use const value (CPY_START_ADDR, CPY_SIZE).
+// Un-comment following line:
+// Adafruit_FlashTransport_RP2040
+//     flashTransport(Adafruit_FlashTransport_RP2040::CPY_START_ADDR,
+//                    Adafruit_FlashTransport_RP2040::CPY_SIZE);
 
 #else
 // On-board external flash (QSPI or SPI) macros should already

--- a/examples/flash_erase/flash_config.h
+++ b/examples/flash_erase/flash_config.h
@@ -33,8 +33,8 @@
 Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-// ESP32 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
+// ESP32 use same flash device that store code for file system.
+// SPIFlash will parse partition.cvs to detect FATFS partition to use
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)

--- a/examples/flash_erase/flash_config.h
+++ b/examples/flash_erase/flash_config.h
@@ -1,0 +1,67 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef FLASH_CONFIG_H_
+#define FLASH_CONFIG_H_
+
+// Un-comment to run example with custom SPI and SS e.g with FRAM breakout
+// #define CUSTOM_CS   A5
+// #define CUSTOM_SPI  SPI
+
+#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+
+#elif defined(ARDUINO_ARCH_ESP32)
+  // ESP32 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  Adafruit_FlashTransport_ESP32 flashTransport;
+
+#elif defined(ARDUINO_ARCH_RP2040)
+  // RP2040 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
+  Adafruit_FlashTransport_RP2040 flashTransport;
+
+  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+  // If start_address and size are both 0, value that match filesystem setting in
+  // 'Tools->Flash Size' menu selection will be used
+
+#else
+  // On-board external flash (QSPI or SPI) macros should already
+  // defined in your board variant if supported
+  // - EXTERNAL_FLASH_USE_QSPI
+  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+  #if defined(EXTERNAL_FLASH_USE_QSPI)
+    Adafruit_FlashTransport_QSPI flashTransport;
+
+  #elif defined(EXTERNAL_FLASH_USE_SPI)
+    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
+  #else
+    #error No (Q)SPI flash are defined for your board !
+  #endif
+#endif
+
+
+#endif

--- a/examples/flash_erase/flash_config.h
+++ b/examples/flash_erase/flash_config.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
@@ -30,38 +30,39 @@
 // #define CUSTOM_SPI  SPI
 
 #if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
+// ESP32 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
+// RP2040 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+// Use default (no-args) constructor to be compatible with CircuitPython
+// partition scheme
+Adafruit_FlashTransport_RP2040 flashTransport;
 
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
+// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+// If start_address and size are both 0, value that match filesystem setting in
+// 'Tools->Flash Size' menu selection will be used
 
 #else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+Adafruit_FlashTransport_QSPI flashTransport;
 
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS,
+                                           EXTERNAL_FLASH_USE_SPI);
 
-  #else
-    #error No (Q)SPI flash are defined for your board !
-  #endif
+#else
+#error No (Q)SPI flash are defined for your board !
 #endif
-
+#endif
 
 #endif

--- a/examples/flash_erase/flash_config.h
+++ b/examples/flash_erase/flash_config.h
@@ -38,15 +38,19 @@ Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-// RP2040 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
-// Use default (no-args) constructor to be compatible with CircuitPython
-// partition scheme
+// RP2040 use same flash device that store code for file system. Therefore we
+// only need to specify start address and size (no need SPI or SS)
+//   Adafruit_FlashTransport_RP2040(start_address, size)
+// If start = 0, size = 0 (default), values that match file system setting in
+// 'Tools->Flash Size' menu selection will be used.
 Adafruit_FlashTransport_RP2040 flashTransport;
 
-// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-// If start_address and size are both 0, value that match filesystem setting in
-// 'Tools->Flash Size' menu selection will be used
+// To be compatible with CircuitPython partition scheme (start_address = 1 MB,
+// size = total flash - 1 MB) use const value (CPY_START_ADDR, CPY_SIZE).
+// Un-comment following line:
+// Adafruit_FlashTransport_RP2040
+//     flashTransport(Adafruit_FlashTransport_RP2040::CPY_START_ADDR,
+//                    Adafruit_FlashTransport_RP2040::CPY_SIZE);
 
 #else
 // On-board external flash (QSPI or SPI) macros should already

--- a/examples/flash_erase/flash_erase.ino
+++ b/examples/flash_erase/flash_erase.ino
@@ -23,36 +23,8 @@
 #include <SdFat.h>
 #include <Adafruit_SPIFlash.h>
 
-#if defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
-
-#elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
-
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
-
-#else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
-
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
-
-  #else
-    #error No QSPI/SPI flash are defined on your board variant.h !
-  #endif
-#endif
+// for flashTransport definition
+#include "flash_config.h"
 
 Adafruit_SPIFlash flash(&flashTransport);
 

--- a/examples/flash_erase/flash_erase.ino
+++ b/examples/flash_erase/flash_erase.ino
@@ -79,7 +79,7 @@ void setup() {
     Serial.println("Type OK (all caps) and press enter to continue.");
     Serial.println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
   }
-  while (!Serial.find("OK"));
+  while (!Serial.find((char*) "OK"));
 
   Serial.println("Erasing flash chip in 10 seconds...");
   Serial.println("Note you will see stat and other debug output printed repeatedly.");

--- a/examples/flash_erase_express/flash_config.h
+++ b/examples/flash_erase_express/flash_config.h
@@ -33,8 +33,8 @@
 Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-// ESP32 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
+// ESP32 use same flash device that store code for file system.
+// SPIFlash will parse partition.cvs to detect FATFS partition to use
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)

--- a/examples/flash_erase_express/flash_config.h
+++ b/examples/flash_erase_express/flash_config.h
@@ -1,0 +1,67 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef FLASH_CONFIG_H_
+#define FLASH_CONFIG_H_
+
+// Un-comment to run example with custom SPI and SS e.g with FRAM breakout
+// #define CUSTOM_CS   A5
+// #define CUSTOM_SPI  SPI
+
+#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+
+#elif defined(ARDUINO_ARCH_ESP32)
+  // ESP32 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  Adafruit_FlashTransport_ESP32 flashTransport;
+
+#elif defined(ARDUINO_ARCH_RP2040)
+  // RP2040 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
+  Adafruit_FlashTransport_RP2040 flashTransport;
+
+  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+  // If start_address and size are both 0, value that match filesystem setting in
+  // 'Tools->Flash Size' menu selection will be used
+
+#else
+  // On-board external flash (QSPI or SPI) macros should already
+  // defined in your board variant if supported
+  // - EXTERNAL_FLASH_USE_QSPI
+  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+  #if defined(EXTERNAL_FLASH_USE_QSPI)
+    Adafruit_FlashTransport_QSPI flashTransport;
+
+  #elif defined(EXTERNAL_FLASH_USE_SPI)
+    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
+  #else
+    #error No (Q)SPI flash are defined for your board !
+  #endif
+#endif
+
+
+#endif

--- a/examples/flash_erase_express/flash_config.h
+++ b/examples/flash_erase_express/flash_config.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
@@ -30,38 +30,39 @@
 // #define CUSTOM_SPI  SPI
 
 #if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
+// ESP32 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
+// RP2040 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+// Use default (no-args) constructor to be compatible with CircuitPython
+// partition scheme
+Adafruit_FlashTransport_RP2040 flashTransport;
 
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
+// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+// If start_address and size are both 0, value that match filesystem setting in
+// 'Tools->Flash Size' menu selection will be used
 
 #else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+Adafruit_FlashTransport_QSPI flashTransport;
 
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS,
+                                           EXTERNAL_FLASH_USE_SPI);
 
-  #else
-    #error No (Q)SPI flash are defined for your board !
-  #endif
+#else
+#error No (Q)SPI flash are defined for your board !
 #endif
-
+#endif
 
 #endif

--- a/examples/flash_erase_express/flash_config.h
+++ b/examples/flash_erase_express/flash_config.h
@@ -38,15 +38,19 @@ Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-// RP2040 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
-// Use default (no-args) constructor to be compatible with CircuitPython
-// partition scheme
+// RP2040 use same flash device that store code for file system. Therefore we
+// only need to specify start address and size (no need SPI or SS)
+//   Adafruit_FlashTransport_RP2040(start_address, size)
+// If start = 0, size = 0 (default), values that match file system setting in
+// 'Tools->Flash Size' menu selection will be used.
 Adafruit_FlashTransport_RP2040 flashTransport;
 
-// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-// If start_address and size are both 0, value that match filesystem setting in
-// 'Tools->Flash Size' menu selection will be used
+// To be compatible with CircuitPython partition scheme (start_address = 1 MB,
+// size = total flash - 1 MB) use const value (CPY_START_ADDR, CPY_SIZE).
+// Un-comment following line:
+// Adafruit_FlashTransport_RP2040
+//     flashTransport(Adafruit_FlashTransport_RP2040::CPY_START_ADDR,
+//                    Adafruit_FlashTransport_RP2040::CPY_SIZE);
 
 #else
 // On-board external flash (QSPI or SPI) macros should already

--- a/examples/flash_erase_express/flash_erase_express.ino
+++ b/examples/flash_erase_express/flash_erase_express.ino
@@ -25,36 +25,8 @@
 #include <Adafruit_SPIFlash.h>
 #include <Adafruit_NeoPixel.h>
 
-#if defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
-
-#elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
-
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
-
-#else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
-
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
-
-  #else
-    #error No QSPI/SPI flash are defined on your board variant.h !
-  #endif
-#endif
+// for flashTransport definition
+#include "flash_config.h"
 
 Adafruit_SPIFlash flash(&flashTransport);
 

--- a/examples/flash_info/flash_config.h
+++ b/examples/flash_info/flash_config.h
@@ -33,8 +33,8 @@
 Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-// ESP32 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
+// ESP32 use same flash device that store code for file system.
+// SPIFlash will parse partition.cvs to detect FATFS partition to use
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)

--- a/examples/flash_info/flash_config.h
+++ b/examples/flash_info/flash_config.h
@@ -1,0 +1,67 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef FLASH_CONFIG_H_
+#define FLASH_CONFIG_H_
+
+// Un-comment to run example with custom SPI and SS e.g with FRAM breakout
+// #define CUSTOM_CS   A5
+// #define CUSTOM_SPI  SPI
+
+#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+
+#elif defined(ARDUINO_ARCH_ESP32)
+  // ESP32 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  Adafruit_FlashTransport_ESP32 flashTransport;
+
+#elif defined(ARDUINO_ARCH_RP2040)
+  // RP2040 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
+  Adafruit_FlashTransport_RP2040 flashTransport;
+
+  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+  // If start_address and size are both 0, value that match filesystem setting in
+  // 'Tools->Flash Size' menu selection will be used
+
+#else
+  // On-board external flash (QSPI or SPI) macros should already
+  // defined in your board variant if supported
+  // - EXTERNAL_FLASH_USE_QSPI
+  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+  #if defined(EXTERNAL_FLASH_USE_QSPI)
+    Adafruit_FlashTransport_QSPI flashTransport;
+
+  #elif defined(EXTERNAL_FLASH_USE_SPI)
+    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
+  #else
+    #error No (Q)SPI flash are defined for your board !
+  #endif
+#endif
+
+
+#endif

--- a/examples/flash_info/flash_config.h
+++ b/examples/flash_info/flash_config.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
@@ -30,38 +30,39 @@
 // #define CUSTOM_SPI  SPI
 
 #if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
+// ESP32 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
+// RP2040 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+// Use default (no-args) constructor to be compatible with CircuitPython
+// partition scheme
+Adafruit_FlashTransport_RP2040 flashTransport;
 
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
+// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+// If start_address and size are both 0, value that match filesystem setting in
+// 'Tools->Flash Size' menu selection will be used
 
 #else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+Adafruit_FlashTransport_QSPI flashTransport;
 
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS,
+                                           EXTERNAL_FLASH_USE_SPI);
 
-  #else
-    #error No (Q)SPI flash are defined for your board !
-  #endif
+#else
+#error No (Q)SPI flash are defined for your board !
 #endif
-
+#endif
 
 #endif

--- a/examples/flash_info/flash_config.h
+++ b/examples/flash_info/flash_config.h
@@ -38,15 +38,19 @@ Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-// RP2040 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
-// Use default (no-args) constructor to be compatible with CircuitPython
-// partition scheme
+// RP2040 use same flash device that store code for file system. Therefore we
+// only need to specify start address and size (no need SPI or SS)
+//   Adafruit_FlashTransport_RP2040(start_address, size)
+// If start = 0, size = 0 (default), values that match file system setting in
+// 'Tools->Flash Size' menu selection will be used.
 Adafruit_FlashTransport_RP2040 flashTransport;
 
-// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-// If start_address and size are both 0, value that match filesystem setting in
-// 'Tools->Flash Size' menu selection will be used
+// To be compatible with CircuitPython partition scheme (start_address = 1 MB,
+// size = total flash - 1 MB) use const value (CPY_START_ADDR, CPY_SIZE).
+// Un-comment following line:
+// Adafruit_FlashTransport_RP2040
+//     flashTransport(Adafruit_FlashTransport_RP2040::CPY_START_ADDR,
+//                    Adafruit_FlashTransport_RP2040::CPY_SIZE);
 
 #else
 // On-board external flash (QSPI or SPI) macros should already

--- a/examples/flash_info/flash_info.ino
+++ b/examples/flash_info/flash_info.ino
@@ -1,50 +1,14 @@
 // The MIT License (MIT)
 // Copyright (c) 2019 Ha Thach for Adafruit Industries
 
-#include "Adafruit_SPIFlash.h"
+#include <SPI.h>
 #include "SdFat.h"
+#include "Adafruit_SPIFlash.h"
 
-// Uncomment to run example with custom SPI and SS e.g with FRAM breakout
-// #define CUSTOM_CS   A5
-// #define CUSTOM_SPI  SPI
-
-#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
-
-#elif defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // SPIFlash can use partition table to detect fatfs partition
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
-
-#elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
-
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
-
-#else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
-
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
-
-  #else
-    #error No QSPI/SPI flash are defined on your board variant.h !
-  #endif
-#endif
+// for flashTransport definition
+#include "flash_config.h"
 
 Adafruit_SPIFlash flash(&flashTransport);
-
 
 /*  If you want to use a specific flash device, for example for a custom built board, first look for it in Adafruit_SPIFlash\src\flash_devices.h
  *  If it isn't in there you need to create your own definition like the W25Q80DLX_EXAMPLE example below.

--- a/examples/flash_info/flash_info.ino
+++ b/examples/flash_info/flash_info.ino
@@ -1,8 +1,8 @@
 // The MIT License (MIT)
 // Copyright (c) 2019 Ha Thach for Adafruit Industries
 
-#include "SdFat.h"
 #include "Adafruit_SPIFlash.h"
+#include "SdFat.h"
 
 // Uncomment to run example with custom SPI and SS e.g with FRAM breakout
 // #define CUSTOM_CS   A5

--- a/examples/flash_manipulator/flash_config.h
+++ b/examples/flash_manipulator/flash_config.h
@@ -33,8 +33,8 @@
 Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-// ESP32 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
+// ESP32 use same flash device that store code for file system.
+// SPIFlash will parse partition.cvs to detect FATFS partition to use
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)

--- a/examples/flash_manipulator/flash_config.h
+++ b/examples/flash_manipulator/flash_config.h
@@ -1,0 +1,67 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef FLASH_CONFIG_H_
+#define FLASH_CONFIG_H_
+
+// Un-comment to run example with custom SPI and SS e.g with FRAM breakout
+// #define CUSTOM_CS   A5
+// #define CUSTOM_SPI  SPI
+
+#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+
+#elif defined(ARDUINO_ARCH_ESP32)
+  // ESP32 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  Adafruit_FlashTransport_ESP32 flashTransport;
+
+#elif defined(ARDUINO_ARCH_RP2040)
+  // RP2040 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
+  Adafruit_FlashTransport_RP2040 flashTransport;
+
+  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+  // If start_address and size are both 0, value that match filesystem setting in
+  // 'Tools->Flash Size' menu selection will be used
+
+#else
+  // On-board external flash (QSPI or SPI) macros should already
+  // defined in your board variant if supported
+  // - EXTERNAL_FLASH_USE_QSPI
+  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+  #if defined(EXTERNAL_FLASH_USE_QSPI)
+    Adafruit_FlashTransport_QSPI flashTransport;
+
+  #elif defined(EXTERNAL_FLASH_USE_SPI)
+    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
+  #else
+    #error No (Q)SPI flash are defined for your board !
+  #endif
+#endif
+
+
+#endif

--- a/examples/flash_manipulator/flash_config.h
+++ b/examples/flash_manipulator/flash_config.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
@@ -30,38 +30,39 @@
 // #define CUSTOM_SPI  SPI
 
 #if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
+// ESP32 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
+// RP2040 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+// Use default (no-args) constructor to be compatible with CircuitPython
+// partition scheme
+Adafruit_FlashTransport_RP2040 flashTransport;
 
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
+// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+// If start_address and size are both 0, value that match filesystem setting in
+// 'Tools->Flash Size' menu selection will be used
 
 #else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+Adafruit_FlashTransport_QSPI flashTransport;
 
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS,
+                                           EXTERNAL_FLASH_USE_SPI);
 
-  #else
-    #error No (Q)SPI flash are defined for your board !
-  #endif
+#else
+#error No (Q)SPI flash are defined for your board !
 #endif
-
+#endif
 
 #endif

--- a/examples/flash_manipulator/flash_config.h
+++ b/examples/flash_manipulator/flash_config.h
@@ -38,15 +38,19 @@ Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-// RP2040 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
-// Use default (no-args) constructor to be compatible with CircuitPython
-// partition scheme
+// RP2040 use same flash device that store code for file system. Therefore we
+// only need to specify start address and size (no need SPI or SS)
+//   Adafruit_FlashTransport_RP2040(start_address, size)
+// If start = 0, size = 0 (default), values that match file system setting in
+// 'Tools->Flash Size' menu selection will be used.
 Adafruit_FlashTransport_RP2040 flashTransport;
 
-// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-// If start_address and size are both 0, value that match filesystem setting in
-// 'Tools->Flash Size' menu selection will be used
+// To be compatible with CircuitPython partition scheme (start_address = 1 MB,
+// size = total flash - 1 MB) use const value (CPY_START_ADDR, CPY_SIZE).
+// Un-comment following line:
+// Adafruit_FlashTransport_RP2040
+//     flashTransport(Adafruit_FlashTransport_RP2040::CPY_START_ADDR,
+//                    Adafruit_FlashTransport_RP2040::CPY_SIZE);
 
 #else
 // On-board external flash (QSPI or SPI) macros should already

--- a/examples/flash_manipulator/flash_manipulator.ino
+++ b/examples/flash_manipulator/flash_manipulator.ino
@@ -154,11 +154,10 @@ void loop(void)
       memset(buffer, 0, pagesize);
       
       int16_t r = dataFile.read(buffer, pagesize);
-      if (r == 0) 
-        break;
+      if (r == 0) break;
       Serial.print("// Writing page ");  Serial.println(page);
 
-      if (r != flash.writeBuffer (page * r, buffer, r)) {
+      if (r != (int) flash.writeBuffer(page * r, buffer, r)) {
         error("Flash write failure");
       }
     }  

--- a/examples/flash_manipulator/flash_manipulator.ino
+++ b/examples/flash_manipulator/flash_manipulator.ino
@@ -1,38 +1,11 @@
 /* This is my go-to example for erasing, dumping, writing and verifying SPI flash!  */
 
+#include <SPI.h>
 #include <SdFat.h>
 #include <Adafruit_SPIFlash.h>
 
-#if defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
-
-#elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
-
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
-
-#else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
-
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
-
-  #else
-    #error No QSPI/SPI flash are defined on your board variant.h !
-  #endif
-#endif
+// for flashTransport definition
+#include "flash_config.h"
 
 Adafruit_SPIFlash flash(&flashTransport);
 
@@ -42,7 +15,7 @@ SdFat sd;
 #define SD_CS 10
 #define MAXPAGESIZE 256
 
-File dataFile;
+File32 dataFile;
 uint8_t buffer[MAXPAGESIZE], buffer2[MAXPAGESIZE];
 uint32_t results;
 

--- a/examples/flash_sector_dump/flash_config.h
+++ b/examples/flash_sector_dump/flash_config.h
@@ -33,8 +33,8 @@
 Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-// ESP32 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
+// ESP32 use same flash device that store code for file system.
+// SPIFlash will parse partition.cvs to detect FATFS partition to use
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)

--- a/examples/flash_sector_dump/flash_config.h
+++ b/examples/flash_sector_dump/flash_config.h
@@ -1,0 +1,67 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef FLASH_CONFIG_H_
+#define FLASH_CONFIG_H_
+
+// Un-comment to run example with custom SPI and SS e.g with FRAM breakout
+// #define CUSTOM_CS   A5
+// #define CUSTOM_SPI  SPI
+
+#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+
+#elif defined(ARDUINO_ARCH_ESP32)
+  // ESP32 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  Adafruit_FlashTransport_ESP32 flashTransport;
+
+#elif defined(ARDUINO_ARCH_RP2040)
+  // RP2040 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
+  Adafruit_FlashTransport_RP2040 flashTransport;
+
+  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+  // If start_address and size are both 0, value that match filesystem setting in
+  // 'Tools->Flash Size' menu selection will be used
+
+#else
+  // On-board external flash (QSPI or SPI) macros should already
+  // defined in your board variant if supported
+  // - EXTERNAL_FLASH_USE_QSPI
+  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+  #if defined(EXTERNAL_FLASH_USE_QSPI)
+    Adafruit_FlashTransport_QSPI flashTransport;
+
+  #elif defined(EXTERNAL_FLASH_USE_SPI)
+    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
+  #else
+    #error No (Q)SPI flash are defined for your board !
+  #endif
+#endif
+
+
+#endif

--- a/examples/flash_sector_dump/flash_config.h
+++ b/examples/flash_sector_dump/flash_config.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
@@ -30,38 +30,39 @@
 // #define CUSTOM_SPI  SPI
 
 #if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
+// ESP32 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
+// RP2040 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+// Use default (no-args) constructor to be compatible with CircuitPython
+// partition scheme
+Adafruit_FlashTransport_RP2040 flashTransport;
 
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
+// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+// If start_address and size are both 0, value that match filesystem setting in
+// 'Tools->Flash Size' menu selection will be used
 
 #else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+Adafruit_FlashTransport_QSPI flashTransport;
 
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS,
+                                           EXTERNAL_FLASH_USE_SPI);
 
-  #else
-    #error No (Q)SPI flash are defined for your board !
-  #endif
+#else
+#error No (Q)SPI flash are defined for your board !
 #endif
-
+#endif
 
 #endif

--- a/examples/flash_sector_dump/flash_config.h
+++ b/examples/flash_sector_dump/flash_config.h
@@ -38,15 +38,19 @@ Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-// RP2040 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
-// Use default (no-args) constructor to be compatible with CircuitPython
-// partition scheme
+// RP2040 use same flash device that store code for file system. Therefore we
+// only need to specify start address and size (no need SPI or SS)
+//   Adafruit_FlashTransport_RP2040(start_address, size)
+// If start = 0, size = 0 (default), values that match file system setting in
+// 'Tools->Flash Size' menu selection will be used.
 Adafruit_FlashTransport_RP2040 flashTransport;
 
-// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-// If start_address and size are both 0, value that match filesystem setting in
-// 'Tools->Flash Size' menu selection will be used
+// To be compatible with CircuitPython partition scheme (start_address = 1 MB,
+// size = total flash - 1 MB) use const value (CPY_START_ADDR, CPY_SIZE).
+// Un-comment following line:
+// Adafruit_FlashTransport_RP2040
+//     flashTransport(Adafruit_FlashTransport_RP2040::CPY_START_ADDR,
+//                    Adafruit_FlashTransport_RP2040::CPY_SIZE);
 
 #else
 // On-board external flash (QSPI or SPI) macros should already

--- a/examples/flash_sector_dump/flash_sector_dump.ino
+++ b/examples/flash_sector_dump/flash_sector_dump.ino
@@ -90,10 +90,11 @@ void loop()
   while( !Serial.available() ) delay(10);
 
   int sector = Serial.parseInt();
+  int sector_max = (int) flash.size()/4096;
 
   Serial.println(sector); // echo
 
-  if ( sector < flash.size()/4096 )
+  if ( sector < sector_max )
   {
     dump_sector(sector);
   }else

--- a/examples/flash_sector_dump/flash_sector_dump.ino
+++ b/examples/flash_sector_dump/flash_sector_dump.ino
@@ -1,45 +1,12 @@
 // The MIT License (MIT)
 // Copyright (c) 2019 Ha Thach for Adafruit Industries
 
+#include <SPI.h>
+#include "SdFat.h"
 #include "Adafruit_SPIFlash.h"
 
-// Uncomment to run example with custom SPI and SS e.g with FRAM breakout
-// #define CUSTOM_CS   A5
-// #define CUSTOM_SPI  SPI
-
-#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
-
-#elif defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
-
-#elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
-
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
-
-#else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
-  
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
-  
-  #else
-    #error No QSPI/SPI flash are defined on your board variant.h !
-  #endif
-#endif
+// for flashTransport definition
+#include "flash_config.h"
 
 Adafruit_SPIFlash flash(&flashTransport);
 

--- a/examples/flash_speedtest/flash_config.h
+++ b/examples/flash_speedtest/flash_config.h
@@ -33,8 +33,8 @@
 Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-// ESP32 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
+// ESP32 use same flash device that store code for file system.
+// SPIFlash will parse partition.cvs to detect FATFS partition to use
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)

--- a/examples/flash_speedtest/flash_config.h
+++ b/examples/flash_speedtest/flash_config.h
@@ -1,0 +1,67 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef FLASH_CONFIG_H_
+#define FLASH_CONFIG_H_
+
+// Un-comment to run example with custom SPI and SS e.g with FRAM breakout
+// #define CUSTOM_CS   A5
+// #define CUSTOM_SPI  SPI
+
+#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+
+#elif defined(ARDUINO_ARCH_ESP32)
+  // ESP32 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  Adafruit_FlashTransport_ESP32 flashTransport;
+
+#elif defined(ARDUINO_ARCH_RP2040)
+  // RP2040 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
+  Adafruit_FlashTransport_RP2040 flashTransport;
+
+  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+  // If start_address and size are both 0, value that match filesystem setting in
+  // 'Tools->Flash Size' menu selection will be used
+
+#else
+  // On-board external flash (QSPI or SPI) macros should already
+  // defined in your board variant if supported
+  // - EXTERNAL_FLASH_USE_QSPI
+  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+  #if defined(EXTERNAL_FLASH_USE_QSPI)
+    Adafruit_FlashTransport_QSPI flashTransport;
+
+  #elif defined(EXTERNAL_FLASH_USE_SPI)
+    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
+  #else
+    #error No (Q)SPI flash are defined for your board !
+  #endif
+#endif
+
+
+#endif

--- a/examples/flash_speedtest/flash_config.h
+++ b/examples/flash_speedtest/flash_config.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
@@ -30,38 +30,39 @@
 // #define CUSTOM_SPI  SPI
 
 #if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
+// ESP32 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
+// RP2040 use same flash device that store code.
+// Therefore there is no need to specify the SPI and SS
+// Use default (no-args) constructor to be compatible with CircuitPython
+// partition scheme
+Adafruit_FlashTransport_RP2040 flashTransport;
 
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
+// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+// If start_address and size are both 0, value that match filesystem setting in
+// 'Tools->Flash Size' menu selection will be used
 
 #else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+Adafruit_FlashTransport_QSPI flashTransport;
 
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS,
+                                           EXTERNAL_FLASH_USE_SPI);
 
-  #else
-    #error No (Q)SPI flash are defined for your board !
-  #endif
+#else
+#error No (Q)SPI flash are defined for your board !
 #endif
-
+#endif
 
 #endif

--- a/examples/flash_speedtest/flash_config.h
+++ b/examples/flash_speedtest/flash_config.h
@@ -38,15 +38,19 @@ Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-// RP2040 use same flash device that store code.
-// Therefore there is no need to specify the SPI and SS
-// Use default (no-args) constructor to be compatible with CircuitPython
-// partition scheme
+// RP2040 use same flash device that store code for file system. Therefore we
+// only need to specify start address and size (no need SPI or SS)
+//   Adafruit_FlashTransport_RP2040(start_address, size)
+// If start = 0, size = 0 (default), values that match file system setting in
+// 'Tools->Flash Size' menu selection will be used.
 Adafruit_FlashTransport_RP2040 flashTransport;
 
-// For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-// If start_address and size are both 0, value that match filesystem setting in
-// 'Tools->Flash Size' menu selection will be used
+// To be compatible with CircuitPython partition scheme (start_address = 1 MB,
+// size = total flash - 1 MB) use const value (CPY_START_ADDR, CPY_SIZE).
+// Un-comment following line:
+// Adafruit_FlashTransport_RP2040
+//     flashTransport(Adafruit_FlashTransport_RP2040::CPY_START_ADDR,
+//                    Adafruit_FlashTransport_RP2040::CPY_SIZE);
 
 #else
 // On-board external flash (QSPI or SPI) macros should already

--- a/examples/flash_speedtest/flash_speedtest.ino
+++ b/examples/flash_speedtest/flash_speedtest.ino
@@ -4,6 +4,8 @@
 #include "SdFat.h"
 #include "Adafruit_SPIFlash.h"
 
+#define TEST_WHOLE_CHIP 1
+
 #ifdef LED_BUILTIN
   uint8_t led_pin = LED_BUILTIN;
 #else
@@ -99,9 +101,7 @@ bool write_and_compare(uint8_t pattern)
   Serial.println("Erase chip");
   Serial.flush();
 
-#define TEST_WHOLE_CHIP
-
-#ifdef TEST_WHOLE_CHIP
+#if TEST_WHOLE_CHIP
   uint32_t const flash_sz = flash.size();
   flash.eraseChip();
 #else

--- a/examples/flash_speedtest/flash_speedtest.ino
+++ b/examples/flash_speedtest/flash_speedtest.ino
@@ -1,8 +1,16 @@
 // The MIT License (MIT)
 // Copyright (c) 2019 Ha Thach for Adafruit Industries
 
+#include <SPI.h>
 #include "SdFat.h"
 #include "Adafruit_SPIFlash.h"
+
+// for flashTransport definition
+#include "flash_config.h"
+
+Adafruit_SPIFlash flash(&flashTransport);
+
+#define BUFSIZE   4096
 
 #define TEST_WHOLE_CHIP 1
 
@@ -11,48 +19,6 @@
 #else
   uint8_t led_pin = 0;
 #endif
-
-// Uncomment to run example with FRAM
-// #define FRAM_CS   A5
-// #define FRAM_SPI  SPI
-
-#if defined(FRAM_CS) && defined(FRAM_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(FRAM_CS, FRAM_SPI);
-
-#elif defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
-
-#elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
-
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
-
-#else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
-
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
-
-  #else
-    #error No QSPI/SPI flash are defined on your board variant.h !
-  #endif
-#endif
-
-Adafruit_SPIFlash flash(&flashTransport);
-
-#define BUFSIZE   4096
 
 // 4 byte aligned buffer has best result with nRF QSPI
 uint8_t bufwrite[BUFSIZE] __attribute__ ((aligned(4)));

--- a/src/Adafruit_SPIFlash.cpp
+++ b/src/Adafruit_SPIFlash.cpp
@@ -139,7 +139,7 @@ bool Adafruit_SPIFlash::readSectors(uint32_t block, uint8_t *dst, size_t nb) {
 }
 
 bool Adafruit_SPIFlash::writeSectors(uint32_t block, const uint8_t *src,
-                                    size_t nb) {
+                                     size_t nb) {
   SPIFLASH_LOG(block, nb);
   if (_flash_dev->is_fram) {
     return this->writeBuffer(block * LOGICAL_BLOCK_SIZE, src,

--- a/src/Adafruit_SPIFlash.cpp
+++ b/src/Adafruit_SPIFlash.cpp
@@ -91,7 +91,7 @@ uint32_t Adafruit_SPIFlash::sectorCount() {
   return Adafruit_SPIFlashBase::size() / LOGICAL_BLOCK_SIZE;
 }
 
-bool Adafruit_SPIFlash::readBlock(uint32_t block, uint8_t *dst) {
+bool Adafruit_SPIFlash::readSector(uint32_t block, uint8_t *dst) {
   SPIFLASH_LOG(block, 1);
 
   if (_flash_dev->is_fram) {
@@ -104,7 +104,7 @@ bool Adafruit_SPIFlash::readBlock(uint32_t block, uint8_t *dst) {
   }
 }
 
-bool Adafruit_SPIFlash::syncBlocks() {
+bool Adafruit_SPIFlash::syncDevice() {
   SPIFLASH_LOG(0, 0);
 
   if (_flash_dev->is_fram) {
@@ -114,7 +114,7 @@ bool Adafruit_SPIFlash::syncBlocks() {
   }
 }
 
-bool Adafruit_SPIFlash::writeBlock(uint32_t block, const uint8_t *src) {
+bool Adafruit_SPIFlash::writeSector(uint32_t block, const uint8_t *src) {
   SPIFLASH_LOG(block, 1);
 
   if (_flash_dev->is_fram) {
@@ -126,7 +126,7 @@ bool Adafruit_SPIFlash::writeBlock(uint32_t block, const uint8_t *src) {
   }
 }
 
-bool Adafruit_SPIFlash::readBlocks(uint32_t block, uint8_t *dst, size_t nb) {
+bool Adafruit_SPIFlash::readSectors(uint32_t block, uint8_t *dst, size_t nb) {
   SPIFLASH_LOG(block, nb);
 
   if (_flash_dev->is_fram) {
@@ -138,7 +138,7 @@ bool Adafruit_SPIFlash::readBlocks(uint32_t block, uint8_t *dst, size_t nb) {
   }
 }
 
-bool Adafruit_SPIFlash::writeBlocks(uint32_t block, const uint8_t *src,
+bool Adafruit_SPIFlash::writeSectors(uint32_t block, const uint8_t *src,
                                     size_t nb) {
   SPIFLASH_LOG(block, nb);
   if (_flash_dev->is_fram) {

--- a/src/Adafruit_SPIFlash.cpp
+++ b/src/Adafruit_SPIFlash.cpp
@@ -28,6 +28,8 @@
 #include "Adafruit_TinyUSB.h"
 #endif
 
+#define LOGICAL_BLOCK_SIZE    512
+
 #if SPIFLASH_DEBUG
 #define SPIFLASH_LOG(_block, _count)                                           \
   do {                                                                         \
@@ -68,29 +70,39 @@ bool Adafruit_SPIFlash::begin(SPIFlash_Device_t const *flash_devs,
   return ret;
 }
 
-bool Adafruit_SPIFlash::end(void) {
-  bool ret = Adafruit_SPIFlashBase::end();
+void Adafruit_SPIFlash::end(void) {
+  // invoke base class end
+  Adafruit_SPIFlashBase::end();
 
-  if (ret && (_cache != NULL)) {
+  if (_cache != NULL) {
     delete _cache;
     _cache = NULL;
   }
-
-  return ret;
 }
 
 //--------------------------------------------------------------------+
 // SdFat BaseBlockDRiver API
 // A block is 512 bytes
 //--------------------------------------------------------------------+
+
+bool Adafruit_SPIFlash::isBusy()
+{
+  return !Adafruit_SPIFlashBase::isReady();
+}
+
+uint32_t Adafruit_SPIFlash::sectorCount()
+{
+  return Adafruit_SPIFlashBase::size()/LOGICAL_BLOCK_SIZE;
+}
+
 bool Adafruit_SPIFlash::readBlock(uint32_t block, uint8_t *dst) {
   SPIFLASH_LOG(block, 1);
 
   if (_flash_dev->is_fram) {
     // FRAM does not need caching
-    return this->readBuffer(block * 512, dst, 512) > 0;
+    return this->readBuffer(block * LOGICAL_BLOCK_SIZE, dst, LOGICAL_BLOCK_SIZE) > 0;
   } else {
-    return _cache->read(this, block * 512, dst, 512);
+    return _cache->read(this, block * LOGICAL_BLOCK_SIZE, dst, LOGICAL_BLOCK_SIZE);
   }
 }
 
@@ -108,9 +120,9 @@ bool Adafruit_SPIFlash::writeBlock(uint32_t block, const uint8_t *src) {
   SPIFLASH_LOG(block, 1);
 
   if (_flash_dev->is_fram) {
-    return this->writeBuffer(block * 512, src, 512) > 0;
+    return this->writeBuffer(block * LOGICAL_BLOCK_SIZE, src, LOGICAL_BLOCK_SIZE) > 0;
   } else {
-    return _cache->write(this, block * 512, src, 512);
+    return _cache->write(this, block * LOGICAL_BLOCK_SIZE, src, LOGICAL_BLOCK_SIZE);
   }
 }
 
@@ -118,9 +130,9 @@ bool Adafruit_SPIFlash::readBlocks(uint32_t block, uint8_t *dst, size_t nb) {
   SPIFLASH_LOG(block, nb);
 
   if (_flash_dev->is_fram) {
-    return this->readBuffer(block * 512, dst, 512 * nb) > 0;
+    return this->readBuffer(block * LOGICAL_BLOCK_SIZE, dst, LOGICAL_BLOCK_SIZE * nb) > 0;
   } else {
-    return _cache->read(this, block * 512, dst, 512 * nb);
+    return _cache->read(this, block * LOGICAL_BLOCK_SIZE, dst, LOGICAL_BLOCK_SIZE * nb);
   }
 }
 
@@ -128,8 +140,8 @@ bool Adafruit_SPIFlash::writeBlocks(uint32_t block, const uint8_t *src,
                                     size_t nb) {
   SPIFLASH_LOG(block, nb);
   if (_flash_dev->is_fram) {
-    return this->writeBuffer(block * 512, src, 512 * nb) > 0;
+    return this->writeBuffer(block * LOGICAL_BLOCK_SIZE, src, LOGICAL_BLOCK_SIZE * nb) > 0;
   } else {
-    return _cache->write(this, block * 512, src, 512 * nb);
+    return _cache->write(this, block * LOGICAL_BLOCK_SIZE, src, LOGICAL_BLOCK_SIZE * nb);
   }
 }

--- a/src/Adafruit_SPIFlash.cpp
+++ b/src/Adafruit_SPIFlash.cpp
@@ -28,7 +28,7 @@
 #include "Adafruit_TinyUSB.h"
 #endif
 
-#define LOGICAL_BLOCK_SIZE    512
+#define LOGICAL_BLOCK_SIZE 512
 
 #if SPIFLASH_DEBUG
 #define SPIFLASH_LOG(_block, _count)                                           \
@@ -85,14 +85,10 @@ void Adafruit_SPIFlash::end(void) {
 // A block is 512 bytes
 //--------------------------------------------------------------------+
 
-bool Adafruit_SPIFlash::isBusy()
-{
-  return !Adafruit_SPIFlashBase::isReady();
-}
+bool Adafruit_SPIFlash::isBusy() { return !Adafruit_SPIFlashBase::isReady(); }
 
-uint32_t Adafruit_SPIFlash::sectorCount()
-{
-  return Adafruit_SPIFlashBase::size()/LOGICAL_BLOCK_SIZE;
+uint32_t Adafruit_SPIFlash::sectorCount() {
+  return Adafruit_SPIFlashBase::size() / LOGICAL_BLOCK_SIZE;
 }
 
 bool Adafruit_SPIFlash::readBlock(uint32_t block, uint8_t *dst) {
@@ -100,9 +96,11 @@ bool Adafruit_SPIFlash::readBlock(uint32_t block, uint8_t *dst) {
 
   if (_flash_dev->is_fram) {
     // FRAM does not need caching
-    return this->readBuffer(block * LOGICAL_BLOCK_SIZE, dst, LOGICAL_BLOCK_SIZE) > 0;
+    return this->readBuffer(block * LOGICAL_BLOCK_SIZE, dst,
+                            LOGICAL_BLOCK_SIZE) > 0;
   } else {
-    return _cache->read(this, block * LOGICAL_BLOCK_SIZE, dst, LOGICAL_BLOCK_SIZE);
+    return _cache->read(this, block * LOGICAL_BLOCK_SIZE, dst,
+                        LOGICAL_BLOCK_SIZE);
   }
 }
 
@@ -120,9 +118,11 @@ bool Adafruit_SPIFlash::writeBlock(uint32_t block, const uint8_t *src) {
   SPIFLASH_LOG(block, 1);
 
   if (_flash_dev->is_fram) {
-    return this->writeBuffer(block * LOGICAL_BLOCK_SIZE, src, LOGICAL_BLOCK_SIZE) > 0;
+    return this->writeBuffer(block * LOGICAL_BLOCK_SIZE, src,
+                             LOGICAL_BLOCK_SIZE) > 0;
   } else {
-    return _cache->write(this, block * LOGICAL_BLOCK_SIZE, src, LOGICAL_BLOCK_SIZE);
+    return _cache->write(this, block * LOGICAL_BLOCK_SIZE, src,
+                         LOGICAL_BLOCK_SIZE);
   }
 }
 
@@ -130,9 +130,11 @@ bool Adafruit_SPIFlash::readBlocks(uint32_t block, uint8_t *dst, size_t nb) {
   SPIFLASH_LOG(block, nb);
 
   if (_flash_dev->is_fram) {
-    return this->readBuffer(block * LOGICAL_BLOCK_SIZE, dst, LOGICAL_BLOCK_SIZE * nb) > 0;
+    return this->readBuffer(block * LOGICAL_BLOCK_SIZE, dst,
+                            LOGICAL_BLOCK_SIZE * nb) > 0;
   } else {
-    return _cache->read(this, block * LOGICAL_BLOCK_SIZE, dst, LOGICAL_BLOCK_SIZE * nb);
+    return _cache->read(this, block * LOGICAL_BLOCK_SIZE, dst,
+                        LOGICAL_BLOCK_SIZE * nb);
   }
 }
 
@@ -140,8 +142,10 @@ bool Adafruit_SPIFlash::writeBlocks(uint32_t block, const uint8_t *src,
                                     size_t nb) {
   SPIFLASH_LOG(block, nb);
   if (_flash_dev->is_fram) {
-    return this->writeBuffer(block * LOGICAL_BLOCK_SIZE, src, LOGICAL_BLOCK_SIZE * nb) > 0;
+    return this->writeBuffer(block * LOGICAL_BLOCK_SIZE, src,
+                             LOGICAL_BLOCK_SIZE * nb) > 0;
   } else {
-    return _cache->write(this, block * LOGICAL_BLOCK_SIZE, src, LOGICAL_BLOCK_SIZE * nb);
+    return _cache->write(this, block * LOGICAL_BLOCK_SIZE, src,
+                         LOGICAL_BLOCK_SIZE * nb);
   }
 }

--- a/src/Adafruit_SPIFlash.h
+++ b/src/Adafruit_SPIFlash.h
@@ -32,8 +32,22 @@
 #include "SdFat.h"
 #include "SdFatConfig.h"
 
-#if ENABLE_EXTENDED_TRANSFER_CLASS == 0
-#error ENABLE_EXTENDED_TRANSFER_CLASS must be set to 1 in SdFat SdFatConfig.h
+
+#if SD_FAT_VERSION >= 20000
+
+  #if USE_BLOCK_DEVICE_INTERFACE == 0
+  #error USE_BLOCK_DEVICE_INTERFACE must be defined to 1 before including SdFat SdFatConfig.
+  #endif
+
+  // v2 rename class and function. TODO should use v2 name, and add define for v1 instead
+  #define BaseBlockDriver FsBlockDeviceInterface
+  #define FatFileSystem   FatVolume
+#else
+
+  #if ENABLE_EXTENDED_TRANSFER_CLASS == 0
+  #error ENABLE_EXTENDED_TRANSFER_CLASS must be set to 1 in SdFat SdFatConfig.h
+  #endif
+
 #endif
 
 #if FAT12_SUPPORT == 0
@@ -52,14 +66,44 @@ public:
   ~Adafruit_SPIFlash() {}
 
   bool begin(SPIFlash_Device_t const *flash_devs = NULL, size_t count = 1);
-  bool end(void);
+  void end(void);
 
-  //------------- SdFat BaseBlockDRiver API -------------//
+  //------------- SdFat v1 BaseBlockDRiver API -------------//
   virtual bool readBlock(uint32_t block, uint8_t *dst);
   virtual bool syncBlocks();
   virtual bool writeBlock(uint32_t block, const uint8_t *src);
   virtual bool readBlocks(uint32_t block, uint8_t *dst, size_t nb);
   virtual bool writeBlocks(uint32_t block, const uint8_t *src, size_t nb);
+
+
+  //------------- SdFat v2 FsBlockDeviceInterface API -------------//
+  virtual bool isBusy();
+  virtual uint32_t sectorCount();
+
+  virtual bool syncDevice()
+  {
+    return syncBlocks();
+  }
+
+  virtual bool readSector(uint32_t block, uint8_t *dst)
+  {
+    return readBlock(block, dst);
+  }
+
+  virtual bool readSectors(uint32_t block, uint8_t *dst, size_t nb)
+  {
+    return readBlocks(block, dst, nb);
+  }
+
+  virtual bool writeSector(uint32_t block, const uint8_t *src)
+  {
+    return writeBlock(block, src);
+  }
+
+  virtual bool writeSectors(uint32_t block, const uint8_t *src, size_t nb)
+  {
+    return writeBlocks(block, src, nb);
+  }
 
 private:
   Adafruit_FlashCache *_cache;

--- a/src/Adafruit_SPIFlash.h
+++ b/src/Adafruit_SPIFlash.h
@@ -37,11 +37,6 @@
 #error USE_BLOCK_DEVICE_INTERFACE must be defined to 1 in SdFatConfig.h. Make sure you use the Adafruit Fork at 'https://github.com/adafruit/SdFat'
 #endif
 
-// Try our best to be Backward-compatible with v1
-#define ENABLE_EXTENDED_TRANSFER_CLASS USE_BLOCK_DEVICE_INTERFACE
-#define BaseBlockDriver FsBlockDeviceInterface
-#define FatFileSystem FatVolume
-
 #else
 
 #if ENABLE_EXTENDED_TRANSFER_CLASS == 0

--- a/src/Adafruit_SPIFlash.h
+++ b/src/Adafruit_SPIFlash.h
@@ -30,7 +30,6 @@
 
 // implement SdFat Block Driver
 #include "SdFat.h"
-#include "SdFatConfig.h"
 
 #if SD_FAT_VERSION >= 20000
 
@@ -41,22 +40,22 @@
 // Try our best to be Backward-compatible with v1
 #define ENABLE_EXTENDED_TRANSFER_CLASS USE_BLOCK_DEVICE_INTERFACE
 #define BaseBlockDriver FsBlockDeviceInterface
-
 #define FatFileSystem FatVolume
 // #define File          File32     // type conflict with other generic File
-// defined
+
 #else
-// Try our best to be Backward-compatible with v1
 
 #if ENABLE_EXTENDED_TRANSFER_CLASS == 0
 #error ENABLE_EXTENDED_TRANSFER_CLASS must be set to 1 in SdFatConfig.h
 #endif
 
+// Try our best to be forward-compatible with v2
 #define USE_BLOCK_DEVICE_INTERFACE ENABLE_EXTENDED_TRANSFER_CLASS
 #define FsBlockDeviceInterface BaseBlockDriver
 #define FatVolume FatFileSystem
 #define File32 File
-#endif
+
+#endif // SD_FAT_VERSION
 
 #if FAT12_SUPPORT == 0
 #error FAT12_SUPPORT must be set to 1 in SdFat SdFatConfig.h

--- a/src/Adafruit_SPIFlash.h
+++ b/src/Adafruit_SPIFlash.h
@@ -34,7 +34,7 @@
 #if SD_FAT_VERSION >= 20000
 
 #if USE_BLOCK_DEVICE_INTERFACE == 0
-#error USE_BLOCK_DEVICE_INTERFACE must be defined to 1 in SdFatConfig.h
+#error USE_BLOCK_DEVICE_INTERFACE must be defined to 1 in SdFatConfig.h. Alternatively you can use the Adafruit Fork at 'https://github.com/adafruit/SdFat' which already set this to 1
 #endif
 
 // Try our best to be Backward-compatible with v1
@@ -46,11 +46,10 @@
 #else
 
 #if ENABLE_EXTENDED_TRANSFER_CLASS == 0
-#error ENABLE_EXTENDED_TRANSFER_CLASS must be set to 1 in SdFatConfig.h
+#error ENABLE_EXTENDED_TRANSFER_CLASS must be set to 1 in SdFatConfig.h. Alternatively you can use the Adafruit Fork at 'https://github.com/adafruit/SdFat' which already set this to 1
 #endif
 
 // Try our best to be forward-compatible with v2
-#define USE_BLOCK_DEVICE_INTERFACE ENABLE_EXTENDED_TRANSFER_CLASS
 #define FsBlockDeviceInterface BaseBlockDriver
 #define FatVolume FatFileSystem
 #define File32 File
@@ -58,7 +57,7 @@
 #endif // SD_FAT_VERSION
 
 #if FAT12_SUPPORT == 0
-#error FAT12_SUPPORT must be set to 1 in SdFat SdFatConfig.h
+#error FAT12_SUPPORT must be set to 1 in SdFat SdFatConfig.h. Alternatively you can use the Adafruit Fork at 'https://github.com/adafruit/SdFat' which already set this to 1
 #endif
 
 // This class extends Adafruit_SPIFlashBase by adding support for the
@@ -75,33 +74,33 @@ public:
   bool begin(SPIFlash_Device_t const *flash_devs = NULL, size_t count = 1);
   void end(void);
 
-  //------------- SdFat v1 BaseBlockDRiver API -------------//
-  virtual bool readBlock(uint32_t block, uint8_t *dst);
-  virtual bool syncBlocks();
-  virtual bool writeBlock(uint32_t block, const uint8_t *src);
-  virtual bool readBlocks(uint32_t block, uint8_t *dst, size_t nb);
-  virtual bool writeBlocks(uint32_t block, const uint8_t *src, size_t nb);
-
   //------------- SdFat v2 FsBlockDeviceInterface API -------------//
   virtual bool isBusy();
   virtual uint32_t sectorCount();
+  virtual bool syncDevice();
 
-  virtual bool syncDevice() { return syncBlocks(); }
+  virtual bool readSector(uint32_t block, uint8_t *dst);
+  virtual bool readSectors(uint32_t block, uint8_t *dst, size_t nb);
+  virtual bool writeSector(uint32_t block, const uint8_t *src);
+  virtual bool writeSectors(uint32_t block, const uint8_t *src, size_t nb);
 
-  virtual bool readSector(uint32_t block, uint8_t *dst) {
-    return readBlock(block, dst);
+  //------------- SdFat v1 BaseBlockDRiver API for backward-compatible -------------//
+  virtual bool syncBlocks() { return syncDevice(); }
+
+  virtual bool readBlock(uint32_t block, uint8_t *dst) {
+    return readSector(block, dst);
   }
 
-  virtual bool readSectors(uint32_t block, uint8_t *dst, size_t nb) {
-    return readBlocks(block, dst, nb);
+  virtual bool readBlocks(uint32_t block, uint8_t *dst, size_t nb) {
+    return readSectors(block, dst, nb);
   }
 
-  virtual bool writeSector(uint32_t block, const uint8_t *src) {
-    return writeBlock(block, src);
+  virtual bool writeBlock(uint32_t block, const uint8_t *src) {
+    return writeSector(block, src);
   }
 
-  virtual bool writeSectors(uint32_t block, const uint8_t *src, size_t nb) {
-    return writeBlocks(block, src, nb);
+  virtual bool writeBlocks(uint32_t block, const uint8_t *src, size_t nb) {
+    return writeSectors(block, src, nb);
   }
 
 private:

--- a/src/Adafruit_SPIFlash.h
+++ b/src/Adafruit_SPIFlash.h
@@ -84,7 +84,7 @@ public:
   virtual bool writeSector(uint32_t block, const uint8_t *src);
   virtual bool writeSectors(uint32_t block, const uint8_t *src, size_t nb);
 
-  //------------- SdFat v1 BaseBlockDRiver API for backward-compatible -------------//
+  // SdFat v1 BaseBlockDRiver API for backward-compatible
   virtual bool syncBlocks() { return syncDevice(); }
 
   virtual bool readBlock(uint32_t block, uint8_t *dst) {

--- a/src/Adafruit_SPIFlash.h
+++ b/src/Adafruit_SPIFlash.h
@@ -34,19 +34,18 @@
 #if SD_FAT_VERSION >= 20000
 
 #if USE_BLOCK_DEVICE_INTERFACE == 0
-#error USE_BLOCK_DEVICE_INTERFACE must be defined to 1 in SdFatConfig.h. Alternatively you can use the Adafruit Fork at 'https://github.com/adafruit/SdFat' which already set this to 1
+#error USE_BLOCK_DEVICE_INTERFACE must be defined to 1 in SdFatConfig.h. Make sure you use the Adafruit Fork at 'https://github.com/adafruit/SdFat'
 #endif
 
 // Try our best to be Backward-compatible with v1
 #define ENABLE_EXTENDED_TRANSFER_CLASS USE_BLOCK_DEVICE_INTERFACE
 #define BaseBlockDriver FsBlockDeviceInterface
 #define FatFileSystem FatVolume
-// #define File          File32     // type conflict with other generic File
 
 #else
 
 #if ENABLE_EXTENDED_TRANSFER_CLASS == 0
-#error ENABLE_EXTENDED_TRANSFER_CLASS must be set to 1 in SdFatConfig.h. Alternatively you can use the Adafruit Fork at 'https://github.com/adafruit/SdFat' which already set this to 1
+#error ENABLE_EXTENDED_TRANSFER_CLASS must be set to 1 in SdFatConfig.h. Make sure you use the Adafruit Fork at 'https://github.com/adafruit/SdFat'
 #endif
 
 // Try our best to be forward-compatible with v2
@@ -57,7 +56,7 @@
 #endif // SD_FAT_VERSION
 
 #if FAT12_SUPPORT == 0
-#error FAT12_SUPPORT must be set to 1 in SdFat SdFatConfig.h. Alternatively you can use the Adafruit Fork at 'https://github.com/adafruit/SdFat' which already set this to 1
+#error FAT12_SUPPORT must be set to 1 in SdFat SdFatConfig.h. Make sure you use the Adafruit Fork at 'https://github.com/adafruit/SdFat'
 #endif
 
 // This class extends Adafruit_SPIFlashBase by adding support for the

--- a/src/Adafruit_SPIFlash.h
+++ b/src/Adafruit_SPIFlash.h
@@ -65,7 +65,8 @@
 // FatFileSystem class.
 //
 // Instances of this class will use 4kB of RAM as a block cache.
-class Adafruit_SPIFlash : public BaseBlockDriver, public Adafruit_SPIFlashBase {
+class Adafruit_SPIFlash : public FsBlockDeviceInterface,
+                          public Adafruit_SPIFlashBase {
 public:
   Adafruit_SPIFlash();
   Adafruit_SPIFlash(Adafruit_FlashTransport *transport);
@@ -80,9 +81,9 @@ public:
   virtual bool syncDevice();
 
   virtual bool readSector(uint32_t block, uint8_t *dst);
-  virtual bool readSectors(uint32_t block, uint8_t *dst, size_t nb);
+  virtual bool readSectors(uint32_t block, uint8_t *dst, size_t ns);
   virtual bool writeSector(uint32_t block, const uint8_t *src);
-  virtual bool writeSectors(uint32_t block, const uint8_t *src, size_t nb);
+  virtual bool writeSectors(uint32_t block, const uint8_t *src, size_t ns);
 
   // SdFat v1 BaseBlockDRiver API for backward-compatible
   virtual bool syncBlocks() { return syncDevice(); }

--- a/src/Adafruit_SPIFlash.h
+++ b/src/Adafruit_SPIFlash.h
@@ -36,18 +36,26 @@
 #if SD_FAT_VERSION >= 20000
 
   #if USE_BLOCK_DEVICE_INTERFACE == 0
-  #error USE_BLOCK_DEVICE_INTERFACE must be defined to 1 before including SdFat SdFatConfig.
+  #error USE_BLOCK_DEVICE_INTERFACE must be defined to 1 in SdFatConfig.h
   #endif
 
-  // v2 rename class and function. TODO should use v2 name, and add define for v1 instead
-  #define BaseBlockDriver FsBlockDeviceInterface
-  #define FatFileSystem   FatVolume
+  // Try our best to be Backward-compatible with v1
+  #define ENABLE_EXTENDED_TRANSFER_CLASS  USE_BLOCK_DEVICE_INTERFACE
+  #define BaseBlockDriver                 FsBlockDeviceInterface
+
+  #define FatFileSystem FatVolume
+  // #define File          File32     // type conflict with other generic File defined
 #else
+  // Try our best to be Backward-compatible with v1
 
   #if ENABLE_EXTENDED_TRANSFER_CLASS == 0
-  #error ENABLE_EXTENDED_TRANSFER_CLASS must be set to 1 in SdFat SdFatConfig.h
+  #error ENABLE_EXTENDED_TRANSFER_CLASS must be set to 1 in SdFatConfig.h
   #endif
 
+  #define USE_BLOCK_DEVICE_INTERFACE  ENABLE_EXTENDED_TRANSFER_CLASS
+  #define FsBlockDeviceInterface      BaseBlockDriver
+  #define FatVolume FatFileSystem
+  #define File32    File
 #endif
 
 #if FAT12_SUPPORT == 0

--- a/src/Adafruit_SPIFlash.h
+++ b/src/Adafruit_SPIFlash.h
@@ -32,30 +32,30 @@
 #include "SdFat.h"
 #include "SdFatConfig.h"
 
-
 #if SD_FAT_VERSION >= 20000
 
-  #if USE_BLOCK_DEVICE_INTERFACE == 0
-  #error USE_BLOCK_DEVICE_INTERFACE must be defined to 1 in SdFatConfig.h
-  #endif
+#if USE_BLOCK_DEVICE_INTERFACE == 0
+#error USE_BLOCK_DEVICE_INTERFACE must be defined to 1 in SdFatConfig.h
+#endif
 
-  // Try our best to be Backward-compatible with v1
-  #define ENABLE_EXTENDED_TRANSFER_CLASS  USE_BLOCK_DEVICE_INTERFACE
-  #define BaseBlockDriver                 FsBlockDeviceInterface
+// Try our best to be Backward-compatible with v1
+#define ENABLE_EXTENDED_TRANSFER_CLASS USE_BLOCK_DEVICE_INTERFACE
+#define BaseBlockDriver FsBlockDeviceInterface
 
-  #define FatFileSystem FatVolume
-  // #define File          File32     // type conflict with other generic File defined
+#define FatFileSystem FatVolume
+// #define File          File32     // type conflict with other generic File
+// defined
 #else
-  // Try our best to be Backward-compatible with v1
+// Try our best to be Backward-compatible with v1
 
-  #if ENABLE_EXTENDED_TRANSFER_CLASS == 0
-  #error ENABLE_EXTENDED_TRANSFER_CLASS must be set to 1 in SdFatConfig.h
-  #endif
+#if ENABLE_EXTENDED_TRANSFER_CLASS == 0
+#error ENABLE_EXTENDED_TRANSFER_CLASS must be set to 1 in SdFatConfig.h
+#endif
 
-  #define USE_BLOCK_DEVICE_INTERFACE  ENABLE_EXTENDED_TRANSFER_CLASS
-  #define FsBlockDeviceInterface      BaseBlockDriver
-  #define FatVolume FatFileSystem
-  #define File32    File
+#define USE_BLOCK_DEVICE_INTERFACE ENABLE_EXTENDED_TRANSFER_CLASS
+#define FsBlockDeviceInterface BaseBlockDriver
+#define FatVolume FatFileSystem
+#define File32 File
 #endif
 
 #if FAT12_SUPPORT == 0
@@ -83,33 +83,25 @@ public:
   virtual bool readBlocks(uint32_t block, uint8_t *dst, size_t nb);
   virtual bool writeBlocks(uint32_t block, const uint8_t *src, size_t nb);
 
-
   //------------- SdFat v2 FsBlockDeviceInterface API -------------//
   virtual bool isBusy();
   virtual uint32_t sectorCount();
 
-  virtual bool syncDevice()
-  {
-    return syncBlocks();
-  }
+  virtual bool syncDevice() { return syncBlocks(); }
 
-  virtual bool readSector(uint32_t block, uint8_t *dst)
-  {
+  virtual bool readSector(uint32_t block, uint8_t *dst) {
     return readBlock(block, dst);
   }
 
-  virtual bool readSectors(uint32_t block, uint8_t *dst, size_t nb)
-  {
+  virtual bool readSectors(uint32_t block, uint8_t *dst, size_t nb) {
     return readBlocks(block, dst, nb);
   }
 
-  virtual bool writeSector(uint32_t block, const uint8_t *src)
-  {
+  virtual bool writeSector(uint32_t block, const uint8_t *src) {
     return writeBlock(block, src);
   }
 
-  virtual bool writeSectors(uint32_t block, const uint8_t *src, size_t nb)
-  {
+  virtual bool writeSectors(uint32_t block, const uint8_t *src, size_t nb) {
     return writeBlocks(block, src, nb);
   }
 

--- a/src/Adafruit_SPIFlashBase.cpp
+++ b/src/Adafruit_SPIFlashBase.cpp
@@ -303,11 +303,10 @@ uint8_t Adafruit_SPIFlashBase::readStatus2(void) {
   return status;
 }
 
-bool Adafruit_SPIFlashBase::isReady(void)
-{
+bool Adafruit_SPIFlashBase::isReady(void) {
   if (_flash_dev->is_fram) {
     return true;
-  }else {
+  } else {
     return (readStatus() & 0x03) == 0;
   }
 }

--- a/src/Adafruit_SPIFlashBase.cpp
+++ b/src/Adafruit_SPIFlashBase.cpp
@@ -258,17 +258,13 @@ bool Adafruit_SPIFlashBase::begin(SPIFlash_Device_t const *flash_devs,
 
 #endif // ARDUINO_ARCH_ESP32
 
-bool Adafruit_SPIFlashBase::end(void) {
-
+void Adafruit_SPIFlashBase::end(void) {
   if (_trans == NULL) {
-    return false;
+    return;
   }
 
   _trans->end();
-
   _flash_dev = NULL;
-
-  return true;
 }
 
 void Adafruit_SPIFlashBase::setIndicator(int pin, bool state_on) {
@@ -305,6 +301,15 @@ uint8_t Adafruit_SPIFlashBase::readStatus2(void) {
   uint8_t status;
   _trans->readCommand(SFLASH_CMD_READ_STATUS2, &status, 1);
   return status;
+}
+
+bool Adafruit_SPIFlashBase::isReady(void)
+{
+  if (_flash_dev->is_fram) {
+    return true;
+  }else {
+    return (readStatus() & 0x03) == 0;
+  }
 }
 
 void Adafruit_SPIFlashBase::waitUntilReady(void) {

--- a/src/Adafruit_SPIFlashBase.h
+++ b/src/Adafruit_SPIFlashBase.h
@@ -28,6 +28,9 @@
 #include "Adafruit_FlashTransport.h"
 #include "flash_devices.h"
 
+// for debugging
+#define SPIFLASH_DEBUG 0
+
 // An easy to use interface for working with Flash memory.
 //
 // If you are managing allocation of the Flash space yourself, this is the
@@ -39,7 +42,7 @@ public:
   ~Adafruit_SPIFlashBase() {}
 
   bool begin(SPIFlash_Device_t const *flash_devs = NULL, size_t count = 1);
-  bool end(void);
+  void end(void);
 
   void setIndicator(int pin, bool state_on = true);
 
@@ -53,6 +56,7 @@ public:
   void waitUntilReady(void);
   bool writeEnable(void);
   bool writeDisable(void);
+  bool isReady(void); // both WIP and WREN are clear
 
   uint32_t getJEDECID(void);
 
@@ -87,8 +91,5 @@ protected:
     }
   }
 };
-
-// for debugging
-#define SPIFLASH_DEBUG 0
 
 #endif /* ADAFRUIT_SPIFLASHBASE_H_ */

--- a/src/rp2040/Adafruit_FlashTransport_RP2040.cpp
+++ b/src/rp2040/Adafruit_FlashTransport_RP2040.cpp
@@ -36,7 +36,7 @@ extern uint8_t _FS_end;
 // FS Size determined by menu selection
 #define MENU_FS_SIZE ((uint32_t)(&_FS_end - &_FS_start))
 
-// CircuitPython partition scheme with start adress = 1 MB, the rest is for
+// CircuitPython partition scheme with start address = 1 MB, the rest is for
 // FileSystem
 // + 4KB since CPY does not reserve EEPROM from arduino core
 #define CPY_START_ADDR (1 * 1024 * 1024)

--- a/src/rp2040/Adafruit_FlashTransport_RP2040.cpp
+++ b/src/rp2040/Adafruit_FlashTransport_RP2040.cpp
@@ -38,9 +38,12 @@ extern uint8_t _FS_end;
 
 // CircuitPython partition scheme with
 // - start address = 1 MB,
-// - size = total flash - 1 MB + 4KB (since CPY does not reserve EEPROM from arduino core)
-const uint32_t Adafruit_FlashTransport_RP2040::CPY_START_ADDR = (1 * 1024 * 1024);
-const uint32_t Adafruit_FlashTransport_RP2040::CPY_SIZE = (((uint32_t)&_FS_end) - (XIP_BASE + CPY_START_ADDR) + 4096);
+// - size = total flash - 1 MB + 4KB (since CPY does not reserve EEPROM from
+// arduino core)
+const uint32_t Adafruit_FlashTransport_RP2040::CPY_START_ADDR =
+    (1 * 1024 * 1024);
+const uint32_t Adafruit_FlashTransport_RP2040::CPY_SIZE =
+    (((uint32_t)&_FS_end) - (XIP_BASE + CPY_START_ADDR) + 4096);
 
 static inline void fl_lock(void) {
   noInterrupts();
@@ -163,7 +166,7 @@ bool Adafruit_FlashTransport_RP2040::eraseCommand(uint8_t command,
     return false;
   }
 
-  if (!check_addr(addr+erase_sz)) {
+  if (!check_addr(addr + erase_sz)) {
     return false;
   }
 
@@ -176,7 +179,7 @@ bool Adafruit_FlashTransport_RP2040::eraseCommand(uint8_t command,
 
 bool Adafruit_FlashTransport_RP2040::readMemory(uint32_t addr, uint8_t *data,
                                                 uint32_t len) {
-  if (!check_addr(addr+len)) {
+  if (!check_addr(addr + len)) {
     return false;
   }
 
@@ -187,7 +190,7 @@ bool Adafruit_FlashTransport_RP2040::readMemory(uint32_t addr, uint8_t *data,
 bool Adafruit_FlashTransport_RP2040::writeMemory(uint32_t addr,
                                                  uint8_t const *data,
                                                  uint32_t len) {
-  if (!check_addr(addr+len)) {
+  if (!check_addr(addr + len)) {
     return false;
   }
 

--- a/src/rp2040/Adafruit_FlashTransport_RP2040.cpp
+++ b/src/rp2040/Adafruit_FlashTransport_RP2040.cpp
@@ -36,11 +36,11 @@ extern uint8_t _FS_end;
 // FS Size determined by menu selection
 #define MENU_FS_SIZE ((uint32_t)(&_FS_end - &_FS_start))
 
-// CircuitPython partition scheme with start address = 1 MB, the rest is for
-// FileSystem
-// + 4KB since CPY does not reserve EEPROM from arduino core
-#define CPY_START_ADDR (1 * 1024 * 1024)
-#define CPY_SIZE (((uint32_t)&_FS_end) - (XIP_BASE + CPY_START_ADDR) + 4096)
+// CircuitPython partition scheme with
+// - start address = 1 MB,
+// - size = total flash - 1 MB + 4KB (since CPY does not reserve EEPROM from arduino core)
+const uint32_t Adafruit_FlashTransport_RP2040::CPY_START_ADDR = (1 * 1024 * 1024);
+const uint32_t Adafruit_FlashTransport_RP2040::CPY_SIZE = (((uint32_t)&_FS_end) - (XIP_BASE + CPY_START_ADDR) + 4096);
 
 static inline void fl_lock(void) {
   noInterrupts();
@@ -52,9 +52,6 @@ static inline void fl_unlock(void) {
   interrupts();
 }
 
-Adafruit_FlashTransport_RP2040::Adafruit_FlashTransport_RP2040(void)
-    : Adafruit_FlashTransport_RP2040(CPY_START_ADDR, CPY_SIZE) {}
-
 Adafruit_FlashTransport_RP2040::Adafruit_FlashTransport_RP2040(
     uint32_t start_addr, uint32_t size) {
   _cmd_read = SFLASH_CMD_READ;
@@ -63,19 +60,19 @@ Adafruit_FlashTransport_RP2040::Adafruit_FlashTransport_RP2040(
   _start_addr = start_addr;
   _size = size;
 
-  memset(&_flash_dev, 0, sizeof(_flash_dev));
-}
-
-void Adafruit_FlashTransport_RP2040::begin(void) {
-  // auto detect start address
+  // detect start address and size that match menu option
   if (!_start_addr) {
     _start_addr = (uint32_t)&_FS_start - XIP_BASE;
   }
 
-  // auto detect size
   if (!_size) {
     _size = MENU_FS_SIZE;
   }
+
+  memset(&_flash_dev, 0, sizeof(_flash_dev));
+}
+
+void Adafruit_FlashTransport_RP2040::begin(void) {
   _flash_dev.total_size = _size;
 
   // Read the RDID register to get the flash capacity.
@@ -114,6 +111,10 @@ void Adafruit_FlashTransport_RP2040::setClockSpeed(uint32_t write_hz,
 }
 
 bool Adafruit_FlashTransport_RP2040::runCommand(uint8_t command) {
+  if (_size < 4096) {
+    return false;
+  }
+
   switch (command) {
   case SFLASH_CMD_ERASE_CHIP:
     fl_lock();
@@ -162,6 +163,10 @@ bool Adafruit_FlashTransport_RP2040::eraseCommand(uint8_t command,
     return false;
   }
 
+  if (!check_addr(addr+erase_sz)) {
+    return false;
+  }
+
   fl_lock();
   flash_range_erase(_start_addr + addr, erase_sz);
   fl_unlock();
@@ -171,6 +176,10 @@ bool Adafruit_FlashTransport_RP2040::eraseCommand(uint8_t command,
 
 bool Adafruit_FlashTransport_RP2040::readMemory(uint32_t addr, uint8_t *data,
                                                 uint32_t len) {
+  if (!check_addr(addr+len)) {
+    return false;
+  }
+
   memcpy(data, (void *)(XIP_BASE + _start_addr + addr), len);
   return true;
 }
@@ -178,6 +187,10 @@ bool Adafruit_FlashTransport_RP2040::readMemory(uint32_t addr, uint8_t *data,
 bool Adafruit_FlashTransport_RP2040::writeMemory(uint32_t addr,
                                                  uint8_t const *data,
                                                  uint32_t len) {
+  if (!check_addr(addr+len)) {
+    return false;
+  }
+
   fl_lock();
   flash_range_program(_start_addr + addr, data, len);
   fl_unlock();

--- a/src/rp2040/Adafruit_FlashTransport_RP2040.h
+++ b/src/rp2040/Adafruit_FlashTransport_RP2040.h
@@ -36,9 +36,7 @@ private:
   SPIFlash_Device_t _flash_dev;
 
   // check if relative addr is valid
-  bool check_addr(uint32_t addr) {
-    return addr <= _size;
-  }
+  bool check_addr(uint32_t addr) { return addr <= _size; }
 
 public:
   static const uint32_t CPY_START_ADDR;

--- a/src/rp2040/Adafruit_FlashTransport_RP2040.h
+++ b/src/rp2040/Adafruit_FlashTransport_RP2040.h
@@ -35,15 +35,23 @@ private:
   uint32_t _size;
   SPIFlash_Device_t _flash_dev;
 
-public:
-  // Default constructor is compatible with CircuitPython partition scheme:
-  // start_address = 1 MB, size = total flash - 1 MB
-  Adafruit_FlashTransport_RP2040(void);
+  // check if relative addr is valid
+  bool check_addr(uint32_t addr) {
+    return addr <= _size;
+  }
 
-  // Generic constructor with address and size.
-  // If start_address and/or size is 0, we will auto detect value to match
-  // filesystem setting in 'Tools->Flash Size' menu selection
-  Adafruit_FlashTransport_RP2040(uint32_t start_addr, uint32_t size);
+public:
+  static const uint32_t CPY_START_ADDR;
+  static const uint32_t CPY_SIZE;
+
+  // Generic constructor with address and size. If start_address and size are 0,
+  // value that matches filesystem setting in 'Tools->Flash Size' menu selection
+  // will be used.
+  //
+  // To be compatible with CircuitPython partition scheme (start_address = 1
+  // MB, size = total flash - 1 MB) use
+  //   Adafruit_FlashTransport_RP2040(CPY_START_ADDR, CPY_SIZE)
+  Adafruit_FlashTransport_RP2040(uint32_t start_addr = 0, uint32_t size = 0);
 
   virtual void begin(void);
   virtual void end(void);

--- a/tools/build_all.py
+++ b/tools/build_all.py
@@ -1,0 +1,109 @@
+import os
+import sys
+import subprocess
+from subprocess import Popen, PIPE
+import time
+import glob
+from multiprocessing import Pool
+
+SUCCEEDED = "\033[32msucceeded\033[0m"
+FAILED = "\033[31mfailed\033[0m"
+SKIPPED = "\033[35mskipped\033[0m"
+WARNING = "\033[33mwarnings\033[0m "
+
+build_format = '| {:35} | {:9} | {:6} |'
+build_separator = '-' * 59
+
+# ci-arduino naming, fqbn
+all_boards = [
+    #['metro_m0_tinyusb', 'adafruit:samd:adafruit_metro_m0:usbstack=tinyusb'],
+    #['metro_m4_tinyusb', 'adafruit:samd:adafruit_metro_m4:speed=120,usbstack=tinyusb'],
+    ['nrf52840', 'adafruit:nrf52:feather52840'],
+    #['feather_rp2040_tinyusb', 'rp2040:rp2040:adafruit_feather:flash=8388608_0,freq=125,dbgport=Disabled,dbglvl=None,usbstack=tinyusb'],
+    #['metroesp32s2', 'esp32:esp32:adafruit_metro_esp32s2:CDCOnBoot=cdc,MSCOnBoot=default,DFUOnBoot=default,UploadMode=cdc,PSRAM=enabled,PartitionScheme=tinyuf2'],
+    #[' ', 'esp32:esp32:adafruit_feather_esp32s3:FlashMode=qio,LoopCore=1,EventsCore=1,USBMode=default,CDCOnBoot=cdc,MSCOnBoot=default,DFUOnBoot=default,UploadMode=cdc,PartitionScheme=tinyuf2'],
+]
+
+# return [succeeded, failed, skipped]
+def build_sketch(variant, sketch):
+    ret = [0, 0, 0]
+
+    name = variant[0]
+    fqbn = variant[1]
+
+    start_time = time.monotonic()
+    # Skip if contains: ".board.test.skip" or ".all.test.skip"
+    # Skip if not contains: ".board.test.only" for a specific board
+    sketchdir = os.path.dirname(sketch)
+    if os.path.exists(sketchdir + '/.all.test.skip') or os.path.exists(sketchdir + '/.' + name + '.test.skip') or \
+            (glob.glob(sketchdir + "/.*.test.only") and not os.path.exists(sketchdir + '/.' + name + '.test.only')):
+        success = SKIPPED
+        ret[2] = 1
+    else:
+        build_result = subprocess.run("arduino-cli compile --warnings all --fqbn {} {}".format(fqbn, sketch),
+                                      shell=True, stdout=PIPE, stderr=PIPE)
+
+        # get stderr into a form where warning/error was output to stderr
+        if build_result.returncode != 0:
+            success = FAILED
+            ret[1] = 1
+        else:
+            ret[0] = 1
+            if build_result.stderr:
+                success = WARNING
+            else:
+                success = SUCCEEDED
+
+    build_duration = time.monotonic() - start_time
+    print(build_format.format(os.path.basename(sketch), success, '{:5.2f}s'.format(build_duration)))
+
+    if success != SKIPPED:
+        # Build failed
+        if build_result.returncode != 0:
+            print(build_result.stdout.decode("utf-8"))
+
+        # Build with warnings
+        if build_result.stderr:
+            print(build_result.stderr.decode("utf-8"))
+    return ret
+
+
+# return [succeeded, failed, skipped]
+def build_variant(variant):
+    print()
+    print(build_separator)
+    print('| {:^56} |'.format('Board ' + variant[0]))
+    print(build_separator)
+    print(build_format.format('Example', '\033[39mResult\033[0m', 'Time'))
+    print(build_separator)
+
+    with Pool(processes=os.cpu_count()) as pool:
+        pool_args = list((map(lambda e, v=variant: [v, e], all_examples)))
+        result = pool.starmap(build_sketch, pool_args)
+        # sum all element of same index (column sum)
+        return list(map(sum, list(zip(*result))))
+
+
+if __name__ == '__main__':
+    # build all variants if input not existed
+    if len(sys.argv) > 1:
+        build_boards = list(filter(lambda x: sys.argv[1] in x[0], all_boards))
+    else:
+        build_boards = all_boards
+
+    all_examples = list(glob.iglob('examples/**/*.ino', recursive=True))
+    all_examples.sort()
+
+    total_time = time.monotonic()
+    total_result = [0, 0, 0]
+    for b in build_boards:
+        ret = build_variant(b)
+        total_result = list(map(lambda x, y: x + y, total_result, ret))
+
+    # Build Summary
+    total_time = time.monotonic() - total_time
+    print(build_separator)
+    print("Build Summary: {} {}, {} {}, {} {} and took {:.2f}s".format(total_result[0], SUCCEEDED, total_result[1],
+                                                                       FAILED, total_result[2], SKIPPED, total_time))
+    print(build_separator)
+    sys.exit(total_result[1])

--- a/tools/update_flash_config.py
+++ b/tools/update_flash_config.py
@@ -1,0 +1,13 @@
+# simple script to update all examples' flash_config.h based on the file in this folder
+
+import os
+import sys
+import glob
+import shutil
+
+new_file = 'tools/flash_config.h'
+
+all_files = list(glob.iglob('examples/*/flash_config.h'))
+
+for f in all_files:
+    shutil.copyfile(new_file, f)


### PR DESCRIPTION
Update SPIFlash to support SdFat v2 (Adafruit's fork). Tested on all platform (samd/nrf/rp2040/esp32s2) and should be safe to merge
- Backward-compatible: working with existing sketch + sdfat v1
- Forward-compatible: working with existing sketch + sdfat v2
- move flashtransport ifdef into flash_config.h for readability and maintaining purpose
- change Adafruit_FlashTransport_RP2040 default constructor to match flash layout in "Tools->Flash Size" menu selection. An CPY_START_ADDR and CPY_SIZE constant are added for cpy compatible layout.

With SDFat v2 there are a few symbol renamed (though old symbol can continue to use thanks to backward-compatible mod to sdfat)
- FatVolume replace FatFileSystem
- File32 replace File/FatFile. Note File should not be used in platform with FS.h such as esp32 and rp2040. In general File32 should be used in all cases
- USE_BLOCK_DEVICE_INTERFACE replace ENABLE_EXTENDED_TRANSFER_CLASS