### PR TITLE
Replace SPIClass with SPIClassSAMD where available

### DIFF
--- a/src/spi/Adafruit_FlashTransport_SPI.h
+++ b/src/spi/Adafruit_FlashTransport_SPI.h
@@ -28,6 +28,10 @@
 #include "Arduino.h"
 #include "SPI.h"
 
+#if defined(ARDUINO_ARCH_SAMD) && defined(_ADAFRUIT_ZERODMA_H_)
+#define SPIClass SPIClassSAMD
+#endif
+
 class Adafruit_FlashTransport_SPI : public Adafruit_FlashTransport {
 private:
   SPIClass *_spi;


### PR DESCRIPTION
Uses SPIClassSAMD instead of traditional SPIClass where supported (hence in boards where [Adafruit_ZeroDMA](https://github.com/adafruit/Adafruit_ZeroDMA) is included).
By using SPIClassSAMD, it is possible to exploit DMA performance increase.

Test running "flash_speedtest.ino" using SPIClass on a 128MBit flash chip:
```
22:43:25.061 -> Adafruit Serial Flash Speed Test example
22:43:25.061 -> JEDEC ID: EF7018
22:43:25.061 -> Flash size: 16777216
22:43:25.061 -> Erase chip
22:44:05.920 -> Write flash with 0xAA
22:45:09.732 -> Write 16777216 bytes in 63.86 seconds.
22:45:09.732 -> Speed: 262.73 KB/s.
22:45:09.732 -> 
22:45:09.732 -> Read flash and compare
22:45:53.275 -> Read  16777216 bytes in 35.78 seconds.
22:45:53.275 -> Speed: 468.86 KB/s.
22:45:53.275 -> 
22:45:53.275 -> Erase chip
22:46:34.055 -> Write flash with 0x55
22:47:37.835 -> Write 16777216 bytes in 63.83 seconds.
22:47:37.835 -> Speed: 262.85 KB/s.
22:47:37.835 -> 
22:47:37.835 -> Read flash and compare
22:48:21.395 -> Read  16777216 bytes in 35.79 seconds.
22:48:21.395 -> Speed: 468.79 KB/s.
22:48:21.395 -> 
22:48:21.395 -> Speed test is completed.
```

Same test but using SPIClassSAMD:
```
22:58:54.773 -> Adafruit Serial Flash Speed Test example
22:58:54.773 -> JEDEC ID: EF7018
22:58:54.773 -> Flash size: 16777216
22:58:54.773 -> Erase chip
22:59:35.795 -> Write flash with 0xAA
23:00:15.566 -> Write 16777216 bytes in 39.79 seconds.
23:00:15.566 -> Speed: 421.64 KB/s.
23:00:15.566 -> 
23:00:15.566 -> Read flash and compare
23:00:37.186 -> Read  16777216 bytes in 13.87 seconds.
23:00:37.186 -> Speed: 1209.52 KB/s.
23:00:37.186 -> 
23:00:37.186 -> Erase chip
23:01:18.059 -> Write flash with 0x55
23:01:57.813 -> Write 16777216 bytes in 39.76 seconds.
23:01:57.813 -> Speed: 421.97 KB/s.
23:01:57.813 -> 
23:01:57.813 -> Read flash and compare
23:02:19.440 -> Read  16777216 bytes in 13.88 seconds.
23:02:19.440 -> Speed: 1208.73 KB/s.
23:02:19.440 -> 
23:02:19.440 -> Speed test is completed.

```