### PR TITLE
Added support for ISSI IS25LP016D SPI flash

### DIFF
--- a/src/Adafruit_SPIFlashBase.cpp
+++ b/src/Adafruit_SPIFlashBase.cpp
@@ -99,7 +99,7 @@ static const SPIFlash_Device_t possible_devices[] = {
     MB85RS64V, MB85RS1MT, MB85RS2MTA, MB85RS4MT,
 
     // Other common flash devices
-    W25Q16JV_IQ, W25Q32JV_IQ, AT25SF041, AT25DF081A};
+    W25Q16JV_IQ, W25Q32JV_IQ, AT25SF041, AT25DF081A, IS25LP016D};
 
 /// Flash device list count
 enum {

--- a/src/flash_devices.h
+++ b/src/flash_devices.h
@@ -30,7 +30,7 @@
 #include <stdint.h>
 
 typedef struct {
-  uint32_t total_size;
+  uint32_t total_size; // in bytes
   uint16_t start_up_time_us;
 
   // Three response bytes to 0x9f JEDEC ID command.
@@ -141,6 +141,19 @@ typedef struct {
     .supports_fast_read = true, .supports_qspi = true,                         \
     .supports_qspi_writes = true, .write_status_register_split = true,         \
     .single_status_byte = false, .is_fram = false,                             \
+  }
+
+// Settings for the ISSI IS25LP016D 16Mib / 2MiB SPI flash. 
+// Datasheet: https://www.issi.com/WW/pdf/25LP-WP016D.pdf
+#define IS25LP016D                                                             \
+  {                                                                            \
+    .total_size = 2097152, /* 2MiB */ .start_up_time_us = 5000,                \
+    .manufacturer_id = 0x9d, .memory_type = 0x60, .capacity = 0x15,            \
+    .max_clock_speed_mhz = 133, .quad_enable_bit_mask = 0x40,                  \
+    .has_sector_protection = false, .supports_fast_read = true,                \
+    .supports_qspi = true, .supports_qspi_writes = true,                       \
+    .write_status_register_split = false, .single_status_byte = true,          \
+    .is_fram = false,                                                          \
   }
 
 // https://www.fujitsu.com/uk/Images/MB85RS64V.pdf


### PR DESCRIPTION
I would like to add Arduino support for this tiny 2MiB USON8 2x3mm flash memory.
Nowadays this flash is supported for CircuitPython on this repository: 

> https://github.com/adafruit/nvm.toml/tree/main/flash/issi

Nevertheless I feel some inconsistency regarding the  `start_up_time_us`, `quad_enable_bit_mask` and `single_status_byte` parameters. Reading the datasheet I think the stated ones here are the correct ones but I'm not completely sure. 

Also It would be really nice to specify at documentation in which unit `total_size` is represented, finally I managed to find out is represented in bytes. It's a bit mess for newcomers because manufacturers uses the notation Mb (Megabit) to refer Mib (Mebibytes). In this case, on datasheet, the memory is stated to be a 16Mb (Megabit) but in fact it has 512 sectos of "4KB", here again the manufacturer uses KB (Kilobytes) for meaning 4KiB (Kibibytes), this is 4096 bytes, so finally the memory has 16Mib (Mebibits) or which is the same, 2MiB (Mebibytes), and this is 2097152 bytes. (See Table 5.1 Block/Sector Addresses).

When executing the `flash_info` example sketch the output given is;

Adafruit Serial Flash Info example
JEDEC ID: 0x9D6015
Flash size: 2048 KB

Here the flash size is given in KB (Kilobytes) instead of KiB (Kibibytes), so the confusion continues ^^".

Thank you very much.