### PR TITLE
QSPI transport should only be used if EXTERNAL_FLASH_USE_QSPI is defined

### DIFF
--- a/src/qspi/Adafruit_FlashTransport_QSPI_NRF.cpp
+++ b/src/qspi/Adafruit_FlashTransport_QSPI_NRF.cpp
@@ -22,7 +22,7 @@
  * THE SOFTWARE.
  */
 
-#ifdef NRF52840_XXAA
+#if defined(NRF52840_XXAA) && defined(EXTERNAL_FLASH_USE_QSPI)
 
 #include "Adafruit_FlashTransport.h"
 #include "nrfx_qspi.h"

--- a/src/qspi/Adafruit_FlashTransport_QSPI_NRF.cpp
+++ b/src/qspi/Adafruit_FlashTransport_QSPI_NRF.cpp
@@ -22,11 +22,12 @@
  * THE SOFTWARE.
  */
 
+#include <Arduino.h>
+
 #if defined(NRF52840_XXAA) && defined(EXTERNAL_FLASH_USE_QSPI)
 
 #include "Adafruit_FlashTransport.h"
 #include "nrfx_qspi.h"
-#include <Arduino.h>
 
 Adafruit_FlashTransport_QSPI::Adafruit_FlashTransport_QSPI(void)
     : Adafruit_FlashTransport_QSPI(PIN_QSPI_SCK, PIN_QSPI_CS, PIN_QSPI_IO0,


### PR DESCRIPTION
This resolves issue #141 

This suggested solution mirrors the suggested usage of EXTERNAL_FLASH_USE_QSPI in examples/flash_info
https://github.com/adafruit/Adafruit_SPIFlash/blob/03d77d3381ce29885fe717a83e343e241f19e358/examples/flash_info/flash_config.h#L65

Possible other solutions might use:
```
#if defined(NRF52840_XXAA) && defined(PIN_QSPI_SCK)
```

I am open to changing the pull request to that pattern if it would work better.