### PR TITLE
skip read jedec id for rp2040

### DIFF
--- a/.codespell/ignore-words.txt
+++ b/.codespell/ignore-words.txt
@@ -1,0 +1,6 @@
+synopsys
+sie
+inout
+busses
+thre
+

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,10 @@
+# See: https://github.com/codespell-project/codespell#using-a-config-file
+[codespell]
+# In the event of a false positive, add the problematic word, in all lowercase, to 'ignore-words.txt' (one word per line).
+# Or copy & paste the whole problematic line to 'exclude-file.txt'
+ignore-words = .codespell/ignore-words.txt
+exclude-file = .codespell/exclude-file.txt
+check-filenames =
+check-hidden =
+count =
+skip = .git

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -3,6 +3,39 @@ name: Build
 on: [pull_request, push, repository_dispatch]
 
 jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.0
+
+      - name: Checkout adafruit/ci-arduino
+        uses: actions/checkout@v3
+        with:
+          repository: adafruit/ci-arduino
+          path: ci
+
+      - name: pre-install
+        run: bash ci/actions_install.sh
+
+      # clang is already run as part of pre-commit
+      # - name: clang
+      # run: python3 ci/run-clang-format.py -r src/arduino
+
+      - name: doxygen
+        env:
+          GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
+          PRETTYNAME : "Adafruit SPIFlash Library"
+        run: bash ci/doxy_gen_and_deploy.sh
+
   build:
     strategy:
       fail-fast: false
@@ -32,8 +65,10 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.x'
+
     - name: Checkout code
       uses: actions/checkout@v3
+
     - name: Checkout adafruit/ci-arduino
       uses: actions/checkout@v3
       with:
@@ -45,16 +80,6 @@ jobs:
 
     - name: test platforms
       run: python3 ci/build_platform.py ${{ matrix.arduino-platform }}
-
-    - name: clang
-      # skip clang for fatfs (ff) to make it easier to compare and upgrade
-      run: python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -e "./examples/SdFat_format/*" -r .
-
-    - name: doxygen
-      env:
-        GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
-        PRETTYNAME : "Adafruit SPIFlash Library"
-      run: bash ci/doxy_gen_and_deploy.sh
 
     - name: Move build artifacts into place
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2020 Diego Elio Pettenò
+#
+# SPDX-License-Identifier: Unlicense
+
+repos:
+- repo: https://github.com/pre-commit/mirrors-clang-format
+  rev: v15.0.7
+  hooks:
+  - id: clang-format
+    exclude: |
+      (?x)^(
+        examples/SdFat_format|
+        tools
+      )
+    types_or: [c++, c, header]
+
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.2.4
+  hooks:
+  - id: codespell
+    args: [-w]
+    exclude: |
+      (?x)^(
+        examples/SdFat_format/ff.c|
+        examples/SdFat_format/ff.h
+      )

--- a/examples/SdFat_Flash_and_SDcard/SdFat_Flash_and_SDcard.ino
+++ b/examples/SdFat_Flash_and_SDcard/SdFat_Flash_and_SDcard.ino
@@ -8,6 +8,7 @@
 
 #include <SPI.h>
 #include <SdFat.h>
+
 #include <Adafruit_SPIFlash.h>
 
 // for flashTransport definition
@@ -18,36 +19,36 @@ SdFat onboardSdCard;
 
 constexpr int getSDCardPin() noexcept {
 #ifdef SDCARD_SS_PIN
-	return SDCARD_SS_PIN;
+  return SDCARD_SS_PIN;
 #else
-	// modify to fit your needs
-	// by default, pin 4 is the SD_CS pin used by the Adafruit 1.8" TFT SD Shield
-	return 4; 
+  // modify to fit your needs
+  // by default, pin 4 is the SD_CS pin used by the Adafruit 1.8" TFT SD Shield
+  return 4;
 #endif
 }
 void setup() {
-	Serial.begin(115200);
-	while (!Serial) {
-		// wait for native usb
-		delay(100); 
-	}
-    Serial.print("Starting up onboard QSPI Flash...");
-    onboardFlash.begin();
-    Serial.println("Done");
-    Serial.println("Onboard Flash information");
-    Serial.print("JEDEC ID: 0x");
-    Serial.println(onboardFlash.getJEDECID(), HEX);
-    Serial.print("Flash size: ");
-    Serial.print(onboardFlash.size() / 1024);
-    Serial.println(" KB");
-    Serial.print("Starting up SD Card...");
-    if (!onboardSdCard.begin(getSDCardPin())) {
-        Serial.println("No card found (is one inserted?)");
-    } else {
-        Serial.println("Card found!");
-    }
+  Serial.begin(115200);
+  while (!Serial) {
+    // wait for native usb
+    delay(100);
+  }
+  Serial.print("Starting up onboard QSPI Flash...");
+  onboardFlash.begin();
+  Serial.println("Done");
+  Serial.println("Onboard Flash information");
+  Serial.print("JEDEC ID: 0x");
+  Serial.println(onboardFlash.getJEDECID(), HEX);
+  Serial.print("Flash size: ");
+  Serial.print(onboardFlash.size() / 1024);
+  Serial.println(" KB");
+  Serial.print("Starting up SD Card...");
+  if (!onboardSdCard.begin(getSDCardPin())) {
+    Serial.println("No card found (is one inserted?)");
+  } else {
+    Serial.println("Card found!");
+  }
 }
 
 void loop() {
-	// nothing to do
+  // nothing to do
 }

--- a/examples/SdFat_OpenNext/SdFat_OpenNext.ino
+++ b/examples/SdFat_OpenNext/SdFat_OpenNext.ino
@@ -2,7 +2,9 @@
  * Print size, modify date/time, and name for all files in root.
  */
 #include <SPI.h>
+
 #include "SdFat.h"
+
 #include "Adafruit_SPIFlash.h"
 
 // for flashTransport definition
@@ -25,12 +27,12 @@ void setup() {
 
   // Init file system on the flash
   fatfs.begin(&flash);
-  
-  // Wait for USB Serial 
+
+  // Wait for USB Serial
   while (!Serial) {
     yield();
   }
-  
+
   if (!root.open("/")) {
     Serial.println("open root failed");
   }
@@ -50,7 +52,7 @@ void setup() {
     Serial.println();
     file.close();
   }
-  
+
   if (root.getError()) {
     Serial.println("openNext failed");
   } else {

--- a/examples/SdFat_ReadWrite/SdFat_ReadWrite.ino
+++ b/examples/SdFat_ReadWrite/SdFat_ReadWrite.ino
@@ -18,7 +18,9 @@
  */
 
 #include <SPI.h>
+
 #include "SdFat.h"
+
 #include "Adafruit_SPIFlash.h"
 
 // for flashTransport definition
@@ -34,19 +36,20 @@ void setup() {
   // Open serial communications and wait for port to open:
   Serial.begin(115200);
   while (!Serial) {
-    delay(10); // wait for serial port to connect. Needed for native USB port only
+    delay(
+        10); // wait for serial port to connect. Needed for native USB port only
   }
 
   Serial.println("Initializing Filesystem on external flash...");
-  
+
   // Init external flash
   flash.begin();
 
   // Open file system on the flash
-  if ( !fatfs.begin(&flash) ) {
-    Serial.println("Error: filesystem is not existed. Please try SdFat_format example to make one.");
-    while(1)
-    {
+  if (!fatfs.begin(&flash)) {
+    Serial.println("Error: filesystem is not existed. Please try SdFat_format "
+                   "example to make one.");
+    while (1) {
       yield();
       delay(1);
     }

--- a/examples/SdFat_circuitpython/SdFat_circuitpython.ino
+++ b/examples/SdFat_circuitpython/SdFat_circuitpython.ino
@@ -21,10 +21,12 @@
 // - Open the serial monitor at 115200 baud.  You should see the
 //   example start to run and messages printed to the monitor.
 //   If you don't see anything close the serial monitor, press
-//   the board reset buttton, wait a few seconds, then open the
+//   the board reset button, wait a few seconds, then open the
 //   serial monitor again.
 #include <SPI.h>
+
 #include <SdFat.h>
+
 #include <Adafruit_SPIFlash.h>
 
 // for flashTransport definition
@@ -46,16 +48,20 @@ void setup() {
   // Initialize flash library and check its chip ID.
   if (!flash.begin()) {
     Serial.println("Error, failed to initialize flash chip!");
-    while(1);
+    while (1) {
+    }
   }
-  Serial.print("Flash chip JEDEC ID: 0x"); Serial.println(flash.getJEDECID(), HEX);
+  Serial.print("Flash chip JEDEC ID: 0x");
+  Serial.println(flash.getJEDECID(), HEX);
 
   // First call begin to mount the filesystem.  Check that it returns true
   // to make sure the filesystem was mounted.
   if (!fatfs.begin(&flash)) {
     Serial.println("Failed to mount filesystem!");
-    Serial.println("Was CircuitPython loaded on the board first to create the filesystem?");
-    while(1);
+    Serial.println("Was CircuitPython loaded on the board first to create the "
+                   "filesystem?");
+    while (1) {
+    }
   }
   Serial.println("Mounted filesystem!");
 
@@ -68,8 +74,7 @@ void setup() {
       Serial.print(c);
     }
     Serial.println();
-  }
-  else {
+  } else {
     Serial.println("No boot.py found...");
   }
 
@@ -82,8 +87,7 @@ void setup() {
       Serial.print(c);
     }
     Serial.println();
-  }
-  else {
+  } else {
     Serial.println("No code.py found...");
   }
 
@@ -98,8 +102,7 @@ void setup() {
     // See the other fatfs examples like fatfs_full_usage and fatfs_datalogging
     // for more examples of interacting with files.
     Serial.println("Wrote a new line to the end of data.txt!");
-  }
-  else {
+  } else {
     Serial.println("Error, failed to open data file for writing!");
   }
 

--- a/examples/SdFat_circuitpython_backupFiles/SdFat_circuitpython_backupFiles.ino
+++ b/examples/SdFat_circuitpython_backupFiles/SdFat_circuitpython_backupFiles.ino
@@ -1,20 +1,21 @@
 // Adafruit M0 Express CircuitPython Repair
 // Author: Limor Fried
 //
-/* 
+/*
  *  This script can be useful if you seriously bork up your CircuitPython
  *  install. It will find any files named main.py, boot.py, main.txt, code.py
  *  or code.txt and move them to backup files. its a tad slow but then you
  *  can reload circuitpython safely. This example right now is only for
  *  the Metro M0 Express & Circuit Playground M0 but i have a...
- *  
+ *
  *  TODO: automagically detect if it's Feather/Metro/CircuitPlayground!
  */
 
 #include <SPI.h>
 #include <SdFat.h>
-#include <Adafruit_SPIFlash.h>
+
 #include <Adafruit_NeoPixel.h>
+#include <Adafruit_SPIFlash.h>
 
 // for flashTransport definition
 #include "flash_config.h"
@@ -24,41 +25,43 @@ Adafruit_SPIFlash flash(&flashTransport);
 // file system object from SdFat
 FatVolume fatfs;
 
-#define NEOPIN         40       // neopixel pin
-#define BUFFERSIZ      200
+#define NEOPIN 40 // neopixel pin
+#define BUFFERSIZ 200
 
 Adafruit_NeoPixel pixel = Adafruit_NeoPixel(1, NEOPIN, NEO_GRB + NEO_KHZ800);
 
 void setup() {
   Serial.begin(115200);
-  //while (!Serial);
-  delay(1000); // small delay in case we want to watch it on the serial port  
+  // while (!Serial);
+  delay(1000); // small delay in case we want to watch it on the serial port
   Serial.println("Adafruit Express CircuitPython Flash Repair");
-  
-  pixel.begin();             // This initializes the NeoPixel library
-  pixel.setBrightness(30);   // not too bright!
-  
+
+  pixel.begin();           // This initializes the NeoPixel library
+  pixel.setBrightness(30); // not too bright!
+
   // Initialize flash library and check its chip ID.
   if (!flash.begin()) {
     Serial.println("Error, failed to initialize flash chip!");
     error(1);
   }
-  Serial.print("Flash chip JEDEC ID: 0x"); Serial.println(flash.getJEDECID(), HEX);
+  Serial.print("Flash chip JEDEC ID: 0x");
+  Serial.println(flash.getJEDECID(), HEX);
 
   // First call begin to mount the filesystem.  Check that it returns true
   // to make sure the filesystem was mounted.
   if (!fatfs.begin(&flash)) {
     Serial.println("Failed to mount filesystem!");
-    Serial.println("Was CircuitPython loaded on the board first to create the filesystem?");
+    Serial.println("Was CircuitPython loaded on the board first to create the "
+                   "filesystem?");
     error(3);
   }
   Serial.println("Mounted filesystem!");
-  
-  moveFile("boot.py", "bootpy.bak");    
-  moveFile("main.py", "mainpy.bak");    
-  moveFile("main.txt", "maintxt.bak");    
-  moveFile("code.py", "codepy.bak");    
-  moveFile("code.txt", "codetxt.bak");    
+
+  moveFile("boot.py", "bootpy.bak");
+  moveFile("main.py", "mainpy.bak");
+  moveFile("main.txt", "maintxt.bak");
+  moveFile("code.py", "codepy.bak");
+  moveFile("code.txt", "codetxt.bak");
 
   Serial.println("Finished!");
 }
@@ -66,18 +69,19 @@ void setup() {
 uint8_t i = 0;
 void loop() {
   // white pixel pulse -> we're done
-  pixel.setPixelColor(0, pixel.Color(i,i,i)); pixel.show();
+  pixel.setPixelColor(0, pixel.Color(i, i, i));
+  pixel.show();
   i++;
   delay(5);
 }
 
-
 boolean moveFile(const char *file, const char *dest) {
-  if (! fatfs.exists(file)) {
-    Serial.print(file); Serial.println(" not found");
+  if (!fatfs.exists(file)) {
+    Serial.print(file);
+    Serial.println(" not found");
     return false;
   }
-  if(fatfs.exists(dest)) {
+  if (fatfs.exists(dest)) {
     Serial.println("Found old backup, removing...");
     if (!fatfs.remove(dest)) {
       Serial.println("Error, couldn't delete ");
@@ -87,7 +91,8 @@ boolean moveFile(const char *file, const char *dest) {
     }
   }
 
-  pixel.setPixelColor(0, pixel.Color(100,100,0)); pixel.show();
+  pixel.setPixelColor(0, pixel.Color(100, 100, 0));
+  pixel.show();
 
   File32 source = fatfs.open(file, FILE_READ);
   File32 backup = fatfs.open(dest, FILE_WRITE);
@@ -96,55 +101,62 @@ boolean moveFile(const char *file, const char *dest) {
 
   while (1) {
     int avail = source.available();
-    //Serial.print("**Available bytes: "); Serial.print(avail); Serial.print("**");
+    // Serial.print("**Available bytes: "); Serial.print(avail);
+    // Serial.print("**");
     if (avail == 0) {
       Serial.println("\n---------------------\n");
       break;
     }
-    int toread = min(BUFFERSIZ-1, avail);
+    int toread = min(BUFFERSIZ - 1, avail);
     char buffer[BUFFERSIZ];
-    
+
     int numread = source.read(buffer, toread);
     if (numread != toread) {
       Serial.print("Failed to read ");
       Serial.print(toread);
-      Serial.print(" bytes, got "); 
+      Serial.print(" bytes, got ");
       Serial.print(numread);
       error(5);
     }
-    buffer[toread] = 0;      
+    buffer[toread] = 0;
     Serial.print(buffer);
-    if ( (int) backup.write(buffer, toread) != toread) {
-        Serial.println("Error, couldn't write data to backup file!");
-        error(6);
+    if ((int)backup.write(buffer, toread) != toread) {
+      Serial.println("Error, couldn't write data to backup file!");
+      error(6);
     }
   }
 
-  pixel.setPixelColor(0, pixel.Color(100,0,100)); pixel.show();
+  pixel.setPixelColor(0, pixel.Color(100, 0, 100));
+  pixel.show();
 
-  Serial.print("Original file size: "); Serial.println(source.size());
-  Serial.print("Backup file size: "); Serial.println(backup.size());
+  Serial.print("Original file size: ");
+  Serial.println(source.size());
+  Serial.print("Backup file size: ");
+  Serial.println(backup.size());
   backup.close();
   if (source.size() == backup.size()) {
-     if (!fatfs.remove(file)) {
-        Serial.print("Error, couldn't delete ");
-        Serial.println(file);
-        error(10);
-     } 
+    if (!fatfs.remove(file)) {
+      Serial.print("Error, couldn't delete ");
+      Serial.println(file);
+      error(10);
+    }
   }
-  pixel.setPixelColor(0, pixel.Color(0,100,0)); pixel.show();
+  pixel.setPixelColor(0, pixel.Color(0, 100, 0));
+  pixel.show();
   delay(100);
   return true;
 }
 
 void error(uint8_t i) {
   while (1) {
-    for (int x = 0; x< i; x++) {
-      pixel.setPixelColor(0, pixel.Color(100,0,0)); pixel.show();
+    for (int x = 0; x < i; x++) {
+      pixel.setPixelColor(0, pixel.Color(100, 0, 0));
+      pixel.show();
       delay(200);
-      pixel.setPixelColor(0, pixel.Color(0,0,0)); pixel.show();
+      pixel.setPixelColor(0, pixel.Color(0, 0, 0));
+      pixel.show();
       delay(200);
     }
-    delay(1000);    
+    delay(1000);
   }
 }

--- a/examples/SdFat_datalogging/SdFat_datalogging.ino
+++ b/examples/SdFat_datalogging/SdFat_datalogging.ino
@@ -17,6 +17,7 @@
 //   value to the data logging file.
 #include <SPI.h>
 #include <SdFat.h>
+
 #include <Adafruit_SPIFlash.h>
 
 // for flashTransport definition
@@ -28,8 +29,7 @@ Adafruit_SPIFlash flash(&flashTransport);
 FatVolume fatfs;
 
 // Configuration for the datalogging file:
-#define FILE_NAME      "data.csv"
-
+#define FILE_NAME "data.csv"
 
 void setup() {
   // Initialize serial port and wait for it to open before continuing.
@@ -42,16 +42,22 @@ void setup() {
   // Initialize flash library and check its chip ID.
   if (!flash.begin()) {
     Serial.println("Error, failed to initialize flash chip!");
-    while(1) delay(1);
+    while (1) {
+      delay(1);
+    }
   }
-  Serial.print("Flash chip JEDEC ID: 0x"); Serial.println(flash.getJEDECID(), HEX);
+  Serial.print("Flash chip JEDEC ID: 0x");
+  Serial.println(flash.getJEDECID(), HEX);
 
   // First call begin to mount the filesystem.  Check that it returns true
   // to make sure the filesystem was mounted.
   if (!fatfs.begin(&flash)) {
     Serial.println("Error, failed to mount newly formatted filesystem!");
-    Serial.println("Was the flash chip formatted with the fatfs_format example?");
-    while(1) delay(1);
+    Serial.println(
+        "Was the flash chip formatted with the fatfs_format example?");
+    while (1) {
+      delay(1);
+    }
   }
   Serial.println("Mounted filesystem!");
 
@@ -66,7 +72,7 @@ void loop() {
   if (dataFile) {
     // Take a new data reading from a sensor, etc.  For this example just
     // make up a random number.
-    int reading = random(0,100);
+    int reading = random(0, 100);
     // Write a line to the file.  You can use all the same print functions
     // as if you're writing to the serial monitor.  For example to write
     // two CSV (commas separated) values:
@@ -78,8 +84,7 @@ void loop() {
     // sure all the data is written to the file.
     dataFile.close();
     Serial.println("Wrote new measurement to data file!");
-  }
-  else {
+  } else {
     Serial.println("Failed to open data file for writing!");
   }
 

--- a/examples/SdFat_format/SdFat_format.ino
+++ b/examples/SdFat_format/SdFat_format.ino
@@ -11,7 +11,7 @@
 // - Upload this sketch to your M0 express board.
 // - Open the serial monitor at 115200 baud.  You should see a
 //   prompt to confirm formatting.  If you don't see the prompt
-//   close the serial monitor, press the board reset buttton,
+//   close the serial monitor, press the board reset button,
 //   wait a few seconds, then open the serial monitor again.
 // - Type OK and enter to confirm the format when prompted.
 // - Partitioning and formatting will take about 30-60 seconds.

--- a/examples/SdFat_format/diskio.h
+++ b/examples/SdFat_format/diskio.h
@@ -1,5 +1,5 @@
 /*-----------------------------------------------------------------------/
-/  Low level disk interface modlue include file   (C)ChaN, 2014          /
+/  Low level disk interface module include file   (C)ChaN, 2014          /
 /-----------------------------------------------------------------------*/
 
 #ifndef _DISKIO_DEFINED
@@ -40,7 +40,7 @@ DRESULT disk_ioctl (BYTE pdrv, BYTE cmd, void* buff);
 #define STA_PROTECT		0x04	/* Write protected */
 
 
-/* Command code for disk_ioctrl fucntion */
+/* Command code for disk_ioctrl function */
 
 /* Generic command (Used by FatFs) */
 #define CTRL_SYNC			0	/* Complete pending write process (needed at FF_FS_READONLY == 0) */

--- a/examples/SdFat_format/ffconf.h
+++ b/examples/SdFat_format/ffconf.h
@@ -132,7 +132,7 @@
 #define FF_LFN_BUF		255
 #define FF_SFN_BUF		12
 /* This set of options defines size of file name members in the FILINFO structure
-/  which is used to read out directory items. These values should be suffcient for
+/  which is used to read out directory items. These values should be sufficient for
 /  the file names to read. The maximum possible length of the read file name depends
 /  on character encoding. When LFN is not enabled, these options have no effect. */
 
@@ -187,7 +187,7 @@
 /  number and only an FAT volume found on the physical drive will be mounted.
 /  When this function is enabled (1), each logical drive number can be bound to
 /  arbitrary physical drive and partition listed in the VolToPart[]. Also f_fdisk()
-/  funciton will be available. */
+/  function will be available. */
 
 
 #define FF_MIN_SS		512
@@ -225,7 +225,7 @@
 
 #define FF_FS_TINY		0
 /* This option switches tiny buffer configuration. (0:Normal or 1:Tiny)
-/  At the tiny configuration, size of file object (FIL) is shrinked FF_MAX_SS bytes.
+/  At the tiny configuration, size of file object (FIL) is shrunk FF_MAX_SS bytes.
 /  Instead of private sector buffer eliminated from the file object, common sector
 /  buffer in the filesystem object (FATFS) is used for the file data transfer. */
 
@@ -240,7 +240,7 @@
 #define FF_NORTC_MON	1
 #define FF_NORTC_MDAY	1
 #define FF_NORTC_YEAR	2019
-/* The option FF_FS_NORTC switches timestamp functiton. If the system does not have
+/* The option FF_FS_NORTC switches timestamp function. If the system does not have
 /  any RTC function or valid timestamp is not needed, set FF_FS_NORTC = 1 to disable
 /  the timestamp function. Every object modified by FatFs will have a fixed timestamp
 /  defined by FF_NORTC_MON, FF_NORTC_MDAY and FF_NORTC_YEAR in local time.

--- a/examples/SdFat_full_usage/SdFat_full_usage.ino
+++ b/examples/SdFat_full_usage/SdFat_full_usage.ino
@@ -20,10 +20,11 @@
 // - Open the serial monitor at 115200 baud.  You should see the
 //   example start to run and messages printed to the monitor.
 //   If you don't see anything close the serial monitor, press
-//   the board reset buttton, wait a few seconds, then open the
+//   the board reset button, wait a few seconds, then open the
 //   serial monitor again.
 #include <SPI.h>
 #include <SdFat.h>
+
 #include <Adafruit_SPIFlash.h>
 
 // for flashTransport definition
@@ -34,12 +35,12 @@ Adafruit_SPIFlash flash(&flashTransport);
 // file system object from SdFat
 FatVolume fatfs;
 
-#define D_TEST                "/test"
-#define D_TEST_FOO_BAR        "/test/foo/bar"
-#define D_TEST_FOO_BAZ        "/test/foo/baz"
+#define D_TEST "/test"
+#define D_TEST_FOO_BAR "/test/foo/bar"
+#define D_TEST_FOO_BAZ "/test/foo/baz"
 
-#define F_TEST_TEST_TXT       "/test/test.txt"
-#define F_TEST_FOO_TEST2_TXT  "/test/foo/test2.txt"
+#define F_TEST_TEST_TXT "/test/test.txt"
+#define F_TEST_FOO_TEST2_TXT "/test/foo/test2.txt"
 
 void setup() {
   // Initialize serial port and wait for it to open before continuing.
@@ -52,32 +53,42 @@ void setup() {
   // Initialize flash library and check its chip ID.
   if (!flash.begin()) {
     Serial.println(F("Error, failed to initialize flash chip!"));
-    while(1) yield();
+    while (1) {
+      yield();
+    }
   }
-  Serial.print(F("Flash chip JEDEC ID: 0x")); Serial.println(flash.getJEDECID(), HEX);
+  Serial.print(F("Flash chip JEDEC ID: 0x"));
+  Serial.println(flash.getJEDECID(), HEX);
 
   // First call begin to mount the filesystem.  Check that it returns true
   // to make sure the filesystem was mounted.
   if (!fatfs.begin(&flash)) {
     Serial.println(F("Error, failed to mount newly formatted filesystem!"));
-    Serial.println(F("Was the flash chip formatted with the SdFat_format example?"));
-    while(1) yield();
+    Serial.println(
+        F("Was the flash chip formatted with the SdFat_format example?"));
+    while (1) {
+      yield();
+    }
   }
   Serial.println(F("Mounted filesystem!"));
 
   // Check if a directory called 'test' exists and create it if not there.
-  // Note you should _not_ add a trailing slash (like '/test/') to directory names!
-  // You can use the same exists function to check for the existance of a file too.
+  // Note you should _not_ add a trailing slash (like '/test/') to directory
+  // names! You can use the same exists function to check for the existence of a
+  // file too.
   if (!fatfs.exists(D_TEST)) {
     Serial.println(F("Test directory not found, creating..."));
-    
-    // Use mkdir to create directory (note you should _not_ have a trailing slash).
+
+    // Use mkdir to create directory (note you should _not_ have a trailing
+    // slash).
     fatfs.mkdir(D_TEST);
-    
-    if ( !fatfs.exists(D_TEST) ) {
+
+    if (!fatfs.exists(D_TEST)) {
       Serial.println(F("Error, failed to create directory!"));
-      while(1) yield();
-    }else {
+      while (1) {
+        yield();
+      }
+    } else {
       Serial.println(F("Created directory!"));
     }
   }
@@ -85,27 +96,32 @@ void setup() {
   // You can also create all the parent subdirectories automatically with mkdir.
   // For example to create the hierarchy /test/foo/bar:
   Serial.println(F("Creating deep folder structure..."));
-  if ( !fatfs.exists(D_TEST_FOO_BAR) ) {
+  if (!fatfs.exists(D_TEST_FOO_BAR)) {
     Serial.println(F("Creating " D_TEST_FOO_BAR));
     fatfs.mkdir(D_TEST_FOO_BAR);
 
-    if ( !fatfs.exists(D_TEST_FOO_BAR) ) {
+    if (!fatfs.exists(D_TEST_FOO_BAR)) {
       Serial.println(F("Error, failed to create directory!"));
-      while(1) yield();
-    }else {
+      while (1) {
+        yield();
+      }
+    } else {
       Serial.println(F("Created directory!"));
     }
   }
 
-  // This will create the hierarchy /test/foo/baz, even when /test/foo already exists:
-  if ( !fatfs.exists(D_TEST_FOO_BAZ) ) {
+  // This will create the hierarchy /test/foo/baz, even when /test/foo already
+  // exists:
+  if (!fatfs.exists(D_TEST_FOO_BAZ)) {
     Serial.println(F("Creating " D_TEST_FOO_BAZ));
     fatfs.mkdir(D_TEST_FOO_BAZ);
 
-    if ( !fatfs.exists(D_TEST_FOO_BAZ) ) {
+    if (!fatfs.exists(D_TEST_FOO_BAZ)) {
       Serial.println(F("Error, failed to create directory!"));
-      while(1) yield();
-    }else {
+      while (1) {
+        yield();
+      }
+    } else {
       Serial.println(F("Created directory!"));
     }
   }
@@ -118,15 +134,19 @@ void setup() {
   File32 writeFile = fatfs.open(F_TEST_TEST_TXT, FILE_WRITE);
   if (!writeFile) {
     Serial.println(F("Error, failed to open " F_TEST_TEST_TXT " for writing!"));
-    while(1) yield();
+    while (1) {
+      yield();
+    }
   }
   Serial.println(F("Opened file " F_TEST_TEST_TXT " for writing/appending..."));
 
   // Once open for writing you can print to the file as if you're printing
   // to the serial terminal, the same functions are available.
   writeFile.println("Hello world!");
-  writeFile.print("Hello number: "); writeFile.println(123, DEC);
-  writeFile.print("Hello hex number: 0x"); writeFile.println(123, HEX);
+  writeFile.print("Hello number: ");
+  writeFile.println(123, DEC);
+  writeFile.print("Hello hex number: 0x");
+  writeFile.println(123, HEX);
 
   // Close the file when finished writing.
   writeFile.close();
@@ -136,32 +156,43 @@ void setup() {
   File32 readFile = fatfs.open(F_TEST_TEST_TXT, FILE_READ);
   if (!readFile) {
     Serial.println(F("Error, failed to open " F_TEST_TEST_TXT " for reading!"));
-    while(1) yield();
+    while (1) {
+      yield();
+    }
   }
 
-  // Read data using the same read, find, readString, etc. functions as when using
-  // the serial class.  See SD library File class for more documentation:
+  // Read data using the same read, find, readString, etc. functions as when
+  // using the serial class.  See SD library File class for more documentation:
   //   https://www.arduino.cc/en/reference/SD
   // Read a line of data:
   String line = readFile.readStringUntil('\n');
-  Serial.print(F("First line of test.txt: ")); Serial.println(line);
+  Serial.print(F("First line of test.txt: "));
+  Serial.println(line);
 
-  // You can get the current position, remaining data, and total size of the file:
-  Serial.print(F("Total size of test.txt (bytes): ")); Serial.println(readFile.size(), DEC);
-  Serial.print(F("Current position in test.txt: ")); Serial.println(readFile.position(), DEC);
-  Serial.print(F("Available data to read in test.txt: ")); Serial.println(readFile.available(), DEC);
+  // You can get the current position, remaining data, and total size of the
+  // file:
+  Serial.print(F("Total size of test.txt (bytes): "));
+  Serial.println(readFile.size(), DEC);
+  Serial.print(F("Current position in test.txt: "));
+  Serial.println(readFile.position(), DEC);
+  Serial.print(F("Available data to read in test.txt: "));
+  Serial.println(readFile.available(), DEC);
 
   // And a few other interesting attributes of a file:
   char readName[64];
   readFile.getName(readName, sizeof(readName));
-  Serial.print(F("File name: ")); Serial.println(readName);
-  Serial.print(F("Is file a directory? ")); Serial.println(readFile.isDirectory() ? F("Yes") : F("No"));
+  Serial.print(F("File name: "));
+  Serial.println(readName);
+  Serial.print(F("Is file a directory? "));
+  Serial.println(readFile.isDirectory() ? F("Yes") : F("No"));
 
   // You can seek around inside the file relative to the start of the file.
   // For example to skip back to the start (position 0):
   if (!readFile.seek(0)) {
     Serial.println(F("Error, failed to seek back to start of file!"));
-    while(1) yield();
+    while (1) {
+      yield();
+    }
   }
 
   // And finally to read all the data and print it out a character at a time
@@ -176,24 +207,30 @@ void setup() {
   readFile.close();
 
   // You can open a directory to list all the children (files and directories).
-  // Just like the SD library the File type represents either a file or directory.
+  // Just like the SD library the File type represents either a file or
+  // directory.
   File32 testDir = fatfs.open(D_TEST);
   if (!testDir) {
     Serial.println(F("Error, failed to open test directory!"));
-    while(1) yield();
+    while (1) {
+      yield();
+    }
   }
   if (!testDir.isDirectory()) {
     Serial.println(F("Error, expected test to be a directory!"));
-    while(1) yield();
+    while (1) {
+      yield();
+    }
   }
   Serial.println(F("Listing children of directory " D_TEST ":"));
   File32 child = testDir.openNextFile();
   while (child) {
     char filename[64];
     child.getName(filename, sizeof(filename));
-    
+
     // Print the file name and mention if it's a directory.
-    Serial.print(F("- ")); Serial.print(filename);
+    Serial.print(F("- "));
+    Serial.print(filename);
     if (child.isDirectory()) {
       Serial.print(F(" (directory)"));
     }
@@ -217,7 +254,9 @@ void setup() {
   Serial.println(F("Deleting " F_TEST_FOO_TEST2_TXT "..."));
   if (!fatfs.remove(F_TEST_FOO_TEST2_TXT)) {
     Serial.println(F("Error, couldn't delete " F_TEST_FOO_TEST2_TXT " file!"));
-    while(1) yield();
+    while (1) {
+      yield();
+    }
   }
   Serial.println(F("Deleted file!"));
 
@@ -228,12 +267,16 @@ void setup() {
   Serial.println(F("Deleting /test directory and everything inside it..."));
   if (!testDir.rmRfStar()) {
     Serial.println(F("Error, couldn't delete test directory!"));
-    while(1) yield();
+    while (1) {
+      yield();
+    }
   }
   // Check that test is really deleted.
   if (fatfs.exists(D_TEST)) {
     Serial.println(F("Error, test directory was not deleted!"));
-    while(1) yield();
+    while (1) {
+      yield();
+    }
   }
   Serial.println(F("Test directory was deleted!"));
 

--- a/examples/SdFat_print_file/SdFat_print_file.ino
+++ b/examples/SdFat_print_file/SdFat_print_file.ino
@@ -16,11 +16,12 @@
 // - Open the serial monitor at 115200 baud.  You should see the
 //   example start to run and messages printed to the monitor.
 //   If you don't see anything close the serial monitor, press
-//   the board reset buttton, wait a few seconds, then open the
+//   the board reset button, wait a few seconds, then open the
 //   serial monitor again.
 
 #include <SPI.h>
 #include <SdFat.h>
+
 #include <Adafruit_SPIFlash.h>
 
 // for flashTransport definition
@@ -32,7 +33,7 @@ Adafruit_SPIFlash flash(&flashTransport);
 FatVolume fatfs;
 
 // Configuration for the file to open and read:
-#define FILE_NAME      "test2.txt"
+#define FILE_NAME "test2.txt"
 
 void setup() {
   // Initialize serial port and wait for it to open before continuing.
@@ -45,16 +46,22 @@ void setup() {
   // Initialize flash library and check its chip ID.
   if (!flash.begin()) {
     Serial.println("Error, failed to initialize flash chip!");
-    while(1) delay(1);
+    while (1) {
+      delay(1);
+    }
   }
-  Serial.print("Flash chip JEDEC ID: 0x"); Serial.println(flash.getJEDECID(), HEX);
+  Serial.print("Flash chip JEDEC ID: 0x");
+  Serial.println(flash.getJEDECID(), HEX);
 
   // First call begin to mount the filesystem.  Check that it returns true
   // to make sure the filesystem was mounted.
   if (!fatfs.begin(&flash)) {
     Serial.println("Error, failed to mount newly formatted filesystem!");
-    Serial.println("Was the flash chip formatted with the fatfs_format example?");
-    while(1) delay(1);
+    Serial.println(
+        "Was the flash chip formatted with the fatfs_format example?");
+    while (1) {
+      delay(1);
+    }
   }
   Serial.println("Mounted filesystem!");
 
@@ -67,13 +74,12 @@ void setup() {
     Serial.println("Opened file, printing contents below:");
     while (dataFile.available()) {
       // Use the read function to read the next character.
-      // You can alternatively use other functions like readUntil, readString, etc.
-      // See the fatfs_full_usage example for more details.
+      // You can alternatively use other functions like readUntil, readString,
+      // etc. See the fatfs_full_usage example for more details.
       char c = dataFile.read();
       Serial.print(c);
     }
-  }
-  else {
+  } else {
     Serial.print("Failed to open file \"");
     Serial.print(FILE_NAME);
     Serial.print("\" !! Does it exist?");

--- a/examples/flash_erase/flash_erase.ino
+++ b/examples/flash_erase/flash_erase.ino
@@ -15,12 +15,13 @@
 // - Upload this sketch to your M0 express board.
 // - Open the serial monitor at 115200 baud.  You should see a
 //   prompt to confirm formatting.  If you don't see the prompt
-//   close the serial monitor, press the board reset buttton,
+//   close the serial monitor, press the board reset button,
 //   wait a few seconds, then open the serial monitor again.
 // - Type OK and enter to confirm the format when prompted,
 //   the flash chip will be erased.
 #include <SPI.h>
 #include <SdFat.h>
+
 #include <Adafruit_SPIFlash.h>
 
 // for flashTransport definition
@@ -39,23 +40,29 @@ void setup() {
   // Initialize flash library and check its chip ID.
   if (!flash.begin()) {
     Serial.println("Error, failed to initialize flash chip!");
-    while(1);
+    while (1) {
+    }
   }
-  Serial.print("Flash chip JEDEC ID: 0x"); Serial.println(flash.getJEDECID(), HEX);
+  Serial.print("Flash chip JEDEC ID: 0x");
+  Serial.println(flash.getJEDECID(), HEX);
 
   // Wait for user to send OK to continue.
-  Serial.setTimeout(30000);  // Increase timeout to print message less frequently.
+  // Increase timeout to print message less frequently.
+  Serial.setTimeout(30000);
   do {
-    Serial.println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+    Serial.println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+                   "!!!!!!!!!!");
     Serial.println("This sketch will ERASE ALL DATA on the flash chip!");
     Serial.println("Type OK (all caps) and press enter to continue.");
-    Serial.println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-  }
-  while (!Serial.find((char*) "OK"));
+    Serial.println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+                   "!!!!!!!!!!");
+  } while (!Serial.find((char *)"OK"));
 
   Serial.println("Erasing flash chip in 10 seconds...");
-  Serial.println("Note you will see stat and other debug output printed repeatedly.");
-  Serial.println("Let it run for ~30 seconds until the flash erase is finished.");
+  Serial.println(
+      "Note you will see stat and other debug output printed repeatedly.");
+  Serial.println(
+      "Let it run for ~30 seconds until the flash erase is finished.");
   Serial.println("An error or success message will be printed when complete.");
 
   if (!flash.eraseChip()) {

--- a/examples/flash_erase_express/flash_erase_express.ino
+++ b/examples/flash_erase_express/flash_erase_express.ino
@@ -22,8 +22,9 @@
 
 #include <SPI.h>
 #include <SdFat.h>
-#include <Adafruit_SPIFlash.h>
+
 #include <Adafruit_NeoPixel.h>
+#include <Adafruit_SPIFlash.h>
 
 // for flashTransport definition
 #include "flash_config.h"
@@ -32,18 +33,19 @@ Adafruit_SPIFlash flash(&flashTransport);
 
 // On-board status Neopixel.
 #if defined(ARDUINO_TRELLIS_M4)
-  #define PIN_NEOPIXEL         10
+#define PIN_NEOPIXEL 10
 #elif defined(ARDUINO_PYPORTAL_M4) || defined(ADAFRUIT_PYPORTAL_M4_TITANO)
-  #define PIN_NEOPIXEL         2
+#define PIN_NEOPIXEL 2
 #elif defined(ADAFRUIT_PYBADGE_M4_EXPRESS)
-  #define PIN_NEOPIXEL         8
+#define PIN_NEOPIXEL 8
 #else
-  // something else?
-  #warning "PIN_NEOPIXEL is not defined/detected, default to 8"
-  #define PIN_NEOPIXEL         8
+// something else?
+#warning "PIN_NEOPIXEL is not defined/detected, default to 8"
+#define PIN_NEOPIXEL 8
 #endif
 
-Adafruit_NeoPixel pixel = Adafruit_NeoPixel(1, PIN_NEOPIXEL, NEO_GRB + NEO_KHZ800);
+Adafruit_NeoPixel pixel =
+    Adafruit_NeoPixel(1, PIN_NEOPIXEL, NEO_GRB + NEO_KHZ800);
 uint32_t BLUE = pixel.Color(0, 0, 100);
 uint32_t GREEN = pixel.Color(0, 100, 0);
 uint32_t YELLOW = pixel.Color(100, 100, 0);
@@ -62,10 +64,10 @@ void setup() {
     // blink red
     blink(2, RED);
   }
-  
+
   pixel.setPixelColor(0, YELLOW);
   pixel.show();
-  
+
   if (!flash.eraseChip()) {
     blink(3, RED);
   }
@@ -91,5 +93,4 @@ void blink(int times, uint32_t color) {
     }
     delay(1000);
   }
-
 }

--- a/examples/flash_info/flash_info.ino
+++ b/examples/flash_info/flash_info.ino
@@ -3,6 +3,7 @@
 
 #include <SPI.h>
 #include <SdFat.h>
+
 #include <Adafruit_SPIFlash.h>
 
 // for flashTransport definition

--- a/examples/flash_manipulator/flash_manipulator.ino
+++ b/examples/flash_manipulator/flash_manipulator.ino
@@ -1,7 +1,9 @@
-/* This is my go-to example for erasing, dumping, writing and verifying SPI flash!  */
+/* This is my go-to example for erasing, dumping, writing and verifying SPI
+ * flash!  */
 
 #include <SPI.h>
 #include <SdFat.h>
+
 #include <Adafruit_SPIFlash.h>
 
 // for flashTransport definition
@@ -21,87 +23,97 @@ uint32_t results;
 
 void error(const char *str) {
   Serial.println(str);
-  while (1) delay(1);
+  while (1) {
+    delay(1);
+  }
 }
 
-void setup(void) 
-{
+void setup(void) {
   Serial.begin(115200);
-  while (!Serial) delay(1);
+  while (!Serial) {
+    delay(1);
+  }
 
   flash.begin();
 
   Serial.println(F("Adafruit Serial Flash Manipulator example"));
-  Serial.print(F("JEDEC ID: ")); Serial.println(flash.getJEDECID(), HEX);
-  Serial.print(F("Flash size: ")); Serial.println(flash.size());
+  Serial.print(F("JEDEC ID: "));
+  Serial.println(flash.getJEDECID(), HEX);
+  Serial.print(F("Flash size: "));
+  Serial.println(flash.size());
 
   Serial.print("Initializing SD card... ");
   // see if the card is present and can be initialized:
   if (!sd.begin(SD_CS, SD_SCK_MHZ(50))) {
     Serial.println("Card failed, or not present");
     // don't do anything more:
-    while (1) delay(1);
+    while (1) {
+      delay(1);
+    }
   }
 
   Serial.println("OK");
 }
 
-void loop(void) 
-{
-  while (Serial.available()) { Serial.read(); }
-  Serial.println(F("FLASH DUMPER - Hello! Press E (rase), W (rite), V (erify), or D (ump) to begin"));
+void loop(void) {
+  while (Serial.available()) {
+    Serial.read();
+  }
+  Serial.println(F("FLASH DUMPER - Hello! Press E (rase), W (rite), V (erify), "
+                   "or D (ump) to begin"));
 
-  while (!Serial.available());
+  while (!Serial.available())
+    ;
   char cmd = toupper(Serial.read());
-  
+
   uint16_t pagesize = flash.pageSize();
   Serial.print(F("Page size: "));
   Serial.println(pagesize);
 
   if (cmd == 'D') {
-     // open the file. note that only one file can be open at a time,
-     // so you have to close this one before opening another.
-     // Open up the file we're going to log to!
-     dataFile = sd.open(F("flshdump.bin"), FILE_WRITE);
-     if (! dataFile) {
-       error("error opening flshdump.bin");
-     }
-    
+    // open the file. note that only one file can be open at a time,
+    // so you have to close this one before opening another.
+    // Open up the file we're going to log to!
+    dataFile = sd.open(F("flshdump.bin"), FILE_WRITE);
+    if (!dataFile) {
+      error("error opening flshdump.bin");
+    }
+
     Serial.println(F("Dumping FLASH to disk"));
-    for (uint32_t page=0; page < flash.numPages() ; page++)  {
+    for (uint32_t page = 0; page < flash.numPages(); page++) {
       memset(buffer, 0, pagesize);
       Serial.print(F("// Reading page "));
       Serial.println(page);
-      uint16_t r = flash.readBuffer (page * pagesize, buffer, pagesize);
-      //Serial.print(r); Serial.print(' '); PrintHex(buffer, r);
+      uint16_t r = flash.readBuffer(page * pagesize, buffer, pagesize);
+      // Serial.print(r); Serial.print(' '); PrintHex(buffer, r);
       dataFile.write(buffer, r);
-    }  
+    }
     dataFile.flush();
     dataFile.close();
   }
   if (cmd == 'E') {
     Serial.println(F("Erasing chip"));
     flash.eraseChip();
-    
   }
   if (cmd == 'V') {
-     dataFile = sd.open("flshdump.bin", FILE_READ);
-     if (! dataFile) {
-       error("error opening flshdump.bin");
-     }
+    dataFile = sd.open("flshdump.bin", FILE_READ);
+    if (!dataFile) {
+      error("error opening flshdump.bin");
+    }
     Serial.println(F("Verifying FLASH from disk"));
-    for (uint32_t page=0; page < flash.numPages() ; page++)  {
+    for (uint32_t page = 0; page < flash.numPages(); page++) {
       memset(buffer, 0, pagesize);
       memset(buffer2, 0, pagesize);
-      
-      Serial.print(F("// Verifying page "));  Serial.println(page);
-      
-      uint32_t r = flash.readBuffer (page * pagesize, buffer, pagesize);
+
+      Serial.print(F("// Verifying page "));
+      Serial.println(page);
+
+      uint32_t r = flash.readBuffer(page * pagesize, buffer, pagesize);
       if (r != pagesize) {
         error("Flash read failure");
       }
-      
-      if (r != (uint32_t) dataFile.read(buffer2, r)) {
+
+      if (r != (uint32_t)dataFile.read(buffer2, r)) {
         error("SD read failure");
       }
 
@@ -110,38 +122,39 @@ void loop(void)
         PrintHex(buffer2, r);
         Serial.println(F("verification failed"));
         return;
-      }      
-    }  
+      }
+    }
     Serial.println(F("Done!"));
     dataFile.close();
-  }  
+  }
 
   if (cmd == 'W') {
-     dataFile = sd.open("flshdump.bin", FILE_READ);
-     if (! dataFile) {
-       error("error opening flshdump.bin");
-     }
+    dataFile = sd.open("flshdump.bin", FILE_READ);
+    if (!dataFile) {
+      error("error opening flshdump.bin");
+    }
 
     Serial.println(F("Writing FLASH from disk"));
-    for (uint32_t page=0; page < flash.numPages() ; page++)  {
+    for (uint32_t page = 0; page < flash.numPages(); page++) {
       memset(buffer, 0, pagesize);
-      
-      int16_t r = dataFile.read(buffer, pagesize);
-      if (r == 0) break;
-      Serial.print(F("// Writing page "));  Serial.println(page);
 
-      if (r != (int) flash.writeBuffer(page * r, buffer, r)) {
+      int16_t r = dataFile.read(buffer, pagesize);
+      if (r == 0)
+        break;
+      Serial.print(F("// Writing page "));
+      Serial.println(page);
+
+      if (r != (int)flash.writeBuffer(page * r, buffer, r)) {
         error("Flash write failure");
       }
-    }  
+    }
     Serial.println(("Done!"));
     dataFile.close();
-  } 
+  }
 }
 
-
 /**************************************************************************/
-/*! 
+/*!
     @brief  Prints a hexadecimal value in plain characters, along with
             the char equivalents in the following format:
 
@@ -151,53 +164,46 @@ void loop(void)
     @param  numBytes  Data length in bytes
 */
 /**************************************************************************/
-void PrintHexChar(const byte * data, const uint32_t numBytes)
-{
+void PrintHexChar(const byte *data, const uint32_t numBytes) {
   uint32_t szPos;
-  for (szPos=0; szPos < numBytes; szPos++) 
-  {
-	// Append leading 0 for small values
-	if (data[szPos] <= 0xF)
+  for (szPos = 0; szPos < numBytes; szPos++) {
+    // Append leading 0 for small values
+    if (data[szPos] <= 0xF)
       Serial.print(F("0"));
-	Serial.print(data[szPos], HEX);
-	if ((numBytes > 1) && (szPos != numBytes - 1))
-	{
-	  Serial.print(F(" "));
-	}
+    Serial.print(data[szPos], HEX);
+    if ((numBytes > 1) && (szPos != numBytes - 1)) {
+      Serial.print(F(" "));
+    }
   }
   Serial.print(F("  "));
-  for (szPos=0; szPos < numBytes; szPos++) 
-  {
+  for (szPos = 0; szPos < numBytes; szPos++) {
     if (data[szPos] <= 0x1F)
-	  Serial.print('.');
-	else
-	  Serial.write(data[szPos]);
+      Serial.print('.');
+    else
+      Serial.write(data[szPos]);
   }
   Serial.println("");
 }
 
 /**************************************************************************/
-/*! 
+/*!
     @brief  Prints a hexadecimal value in plain characters
 
     @param  data      Pointer to the byte data
     @param  numBytes  Data length in bytes
 */
 /**************************************************************************/
-void PrintHex(const byte * data, const uint32_t numBytes)
-{
+void PrintHex(const byte *data, const uint32_t numBytes) {
   uint32_t szPos;
-  for (szPos=0; szPos < numBytes; szPos++) 
-  {
+  for (szPos = 0; szPos < numBytes; szPos++) {
     Serial.print(F("0x"));
-	// Append leading 0 for small values
-	if (data[szPos] <= 0xF)
+    // Append leading 0 for small values
+    if (data[szPos] <= 0xF)
       Serial.print(F("0"));
-	Serial.print(data[szPos], HEX);
-	if ((numBytes > 1) && (szPos != numBytes - 1))
-	{
-	  Serial.print(F(" "));
-	}
+    Serial.print(data[szPos], HEX);
+    if ((numBytes > 1) && (szPos != numBytes - 1)) {
+      Serial.print(F(" "));
+    }
   }
   Serial.println("");
 }

--- a/examples/flash_sector_dump/flash_sector_dump.ino
+++ b/examples/flash_sector_dump/flash_sector_dump.ino
@@ -1,8 +1,9 @@
 // The MIT License (MIT)
 // Copyright (c) 2019 Ha Thach for Adafruit Industries
 
-#include <SPI.h>
+#include "SPI.h"
 #include "SdFat.h"
+
 #include "Adafruit_SPIFlash.h"
 
 // for flashTransport definition
@@ -11,37 +12,40 @@
 Adafruit_SPIFlash flash(&flashTransport);
 
 // the setup function runs once when you press reset or power the board
-void setup()
-{
+void setup() {
   Serial.begin(115200);
-  while ( !Serial ) delay(10);   // wait for native usb
+  while (!Serial) {
+    delay(10); // wait for native usb
+  }
 
   flash.begin();
-  
+
   Serial.println("Adafruit Serial Flash Sector Dump example");
-  Serial.print("JEDEC ID: "); Serial.println(flash.getJEDECID(), HEX);
-  Serial.print("Flash size: "); Serial.println(flash.size());
+  Serial.print("JEDEC ID: ");
+  Serial.println(flash.getJEDECID(), HEX);
+  Serial.print("Flash size: ");
+  Serial.println(flash.size());
 }
 
-void dump_sector(uint32_t sector)
-{
+void dump_sector(uint32_t sector) {
   uint8_t buf[4096];
   memset(buf, 0xff, sizeof(buf));
-  
-  flash.readBuffer(sector*4096, buf, 4096);
 
-  for(uint32_t row=0; row<sizeof(buf)/16; row++)
-  {
-    if ( row == 0 ) Serial.print("0");
-    if ( row < 16 ) Serial.print("0");
-    Serial.print(row*16, HEX);
+  flash.readBuffer(sector * 4096, buf, 4096);
+
+  for (uint32_t row = 0; row < sizeof(buf) / 16; row++) {
+    if (row == 0)
+      Serial.print("0");
+    if (row < 16)
+      Serial.print("0");
+    Serial.print(row * 16, HEX);
     Serial.print(" : ");
 
-    for(uint32_t col=0; col<16; col++)
-    {
-      uint8_t val = buf[row*16 + col];
+    for (uint32_t col = 0; col < 16; col++) {
+      uint8_t val = buf[row * 16 + col];
 
-      if ( val < 16 ) Serial.print("0");
+      if (val < 16)
+        Serial.print("0");
       Serial.print(val, HEX);
 
       Serial.print(" ");
@@ -51,21 +55,20 @@ void dump_sector(uint32_t sector)
   }
 }
 
-void loop()
-{
+void loop() {
   Serial.print("Enter the sector number to dump: ");
-  while( !Serial.available() ) delay(10);
+  while (!Serial.available()) {
+    delay(10);
+  }
 
   int sector = Serial.parseInt();
-  int sector_max = (int) flash.size()/4096;
+  int sector_max = (int)flash.size() / 4096;
 
   Serial.println(sector); // echo
 
-  if ( sector < sector_max )
-  {
+  if (sector < sector_max) {
     dump_sector(sector);
-  }else
-  {
+  } else {
     Serial.println("Invalid sector number");
   }
 

--- a/examples/flash_speedtest/flash_speedtest.ino
+++ b/examples/flash_speedtest/flash_speedtest.ino
@@ -2,7 +2,8 @@
 // Copyright (c) 2019 Ha Thach for Adafruit Industries
 
 #include <SPI.h>
-#include "SdFat.h"
+#include <SdFat.h>
+
 #include "Adafruit_SPIFlash.h"
 
 // for flashTransport definition
@@ -11,37 +12,39 @@
 Adafruit_SPIFlash flash(&flashTransport);
 
 #ifdef __AVR__
-#define BUFSIZE   512
+#define BUFSIZE 512
 #else
-#define BUFSIZE   4096
+#define BUFSIZE 4096
 #endif
 
 #define TEST_WHOLE_CHIP 1
 
 #ifdef LED_BUILTIN
-  uint8_t led_pin = LED_BUILTIN;
+uint8_t led_pin = LED_BUILTIN;
 #else
-  uint8_t led_pin = 0;
+uint8_t led_pin = 0;
 #endif
 
 // 4 byte aligned buffer has best result with nRF QSPI
-uint8_t bufwrite[BUFSIZE] __attribute__ ((aligned(4)));
-uint8_t bufread[BUFSIZE] __attribute__ ((aligned(4)));
+uint8_t bufwrite[BUFSIZE] __attribute__((aligned(4)));
+uint8_t bufread[BUFSIZE] __attribute__((aligned(4)));
 
 // the setup function runs once when you press reset or power the board
-void setup()
-{
+void setup() {
   Serial.begin(115200);
-  while ( !Serial ) delay(100);   // wait for native usb
-
+  while (!Serial) {
+    delay(100); // wait for native usb
+  }
   flash.begin();
 
   pinMode(led_pin, OUTPUT);
   flash.setIndicator(led_pin, true);
 
   Serial.println("Adafruit Serial Flash Speed Test example");
-  Serial.print("JEDEC ID: "); Serial.println(flash.getJEDECID(), HEX);
-  Serial.print("Flash size: "); Serial.println(flash.size());
+  Serial.print("JEDEC ID: ");
+  Serial.println(flash.getJEDECID(), HEX);
+  Serial.print("Flash size: ");
+  Serial.println(flash.size());
   Serial.flush();
 
   write_and_compare(0xAA);
@@ -51,8 +54,7 @@ void setup()
   Serial.flush();
 }
 
-void print_speed(const char* text, uint32_t count, uint32_t ms)
-{
+void print_speed(const char *text, uint32_t count, uint32_t ms) {
   Serial.print(text);
   Serial.print(count);
   Serial.print(" bytes in ");
@@ -60,12 +62,11 @@ void print_speed(const char* text, uint32_t count, uint32_t ms)
   Serial.println(" seconds.");
 
   Serial.print("Speed: ");
-  Serial.print( (count / 1000.0F) / (ms / 1000.0F), 2);
+  Serial.print((count / 1000.0F) / (ms / 1000.0F), 2);
   Serial.println(" KB/s.\r\n");
 }
 
-bool write_and_compare(uint8_t pattern)
-{
+bool write_and_compare(uint8_t pattern) {
   uint32_t ms;
 
   Serial.println("Erase chip");
@@ -82,14 +83,13 @@ bool write_and_compare(uint8_t pattern)
   flash.waitUntilReady();
 
   // write all
-  memset(bufwrite, (int) pattern, sizeof(bufwrite));
+  memset(bufwrite, (int)pattern, sizeof(bufwrite));
   Serial.print("Write flash with 0x");
   Serial.println(pattern, HEX);
   Serial.flush();
   ms = millis();
 
-  for(uint32_t addr = 0; addr < flash_sz; addr += sizeof(bufwrite))
-  {
+  for (uint32_t addr = 0; addr < flash_sz; addr += sizeof(bufwrite)) {
     flash.writeBuffer(addr, bufwrite, sizeof(bufwrite));
   }
 
@@ -101,31 +101,31 @@ bool write_and_compare(uint8_t pattern)
   Serial.println("Read flash and compare");
   Serial.flush();
   uint32_t ms_read = 0;
-  for(uint32_t addr = 0; addr < flash_sz; addr += sizeof(bufread))
-  {
+  for (uint32_t addr = 0; addr < flash_sz; addr += sizeof(bufread)) {
     memset(bufread, 0, sizeof(bufread));
 
     ms = millis();
     flash.readBuffer(addr, bufread, sizeof(bufread));
     ms_read += millis() - ms;
 
-    if ( memcmp(bufwrite, bufread, BUFSIZE) )
-    {
+    if (memcmp(bufwrite, bufread, BUFSIZE)) {
       Serial.print("Error: flash contents mismatched at address 0x");
       Serial.println(addr, HEX);
-      for(uint32_t i=0; i<sizeof(bufread); i++)
-      {
-        if ( i != 0 ) Serial.print(' ');
-        if ( (i%16 == 0) )
-        {
+      for (uint32_t i = 0; i < sizeof(bufread); i++) {
+        if (i != 0)
+          Serial.print(' ');
+        if ((i % 16 == 0)) {
           Serial.println();
-          if ( i < 0x100 ) Serial.print('0');
-          if ( i < 0x010 ) Serial.print('0');
+          if (i < 0x100)
+            Serial.print('0');
+          if (i < 0x010)
+            Serial.print('0');
           Serial.print(i, HEX);
           Serial.print(": ");
         }
 
-        if (bufread[i] < 0x10) Serial.print('0');
+        if (bufread[i] < 0x10)
+          Serial.print('0');
         Serial.print(bufread[i], HEX);
       }
 
@@ -140,7 +140,6 @@ bool write_and_compare(uint8_t pattern)
   return true;
 }
 
-void loop()
-{
+void loop() {
   // nothing to do
 }

--- a/src/Adafruit_FlashTransport.h
+++ b/src/Adafruit_FlashTransport.h
@@ -100,7 +100,7 @@ public:
 
   /// Erase external flash by address
   /// @param command  can be sector erase (0x20) or block erase 0xD8
-  /// @param address  adddress to be erased
+  /// @param address  address to be erased
   /// @return true if success
   virtual bool eraseCommand(uint8_t command, uint32_t address) = 0;
 

--- a/src/Adafruit_SPIFlashBase.cpp
+++ b/src/Adafruit_SPIFlashBase.cpp
@@ -32,7 +32,7 @@
 #define SPIFLASH_LOG(_address, _count)                                         \
   do {                                                                         \
     Serial.print(__FUNCTION__);                                                \
-    Serial.print(": adddress = ");                                             \
+    Serial.print(": address = ");                                              \
     Serial.print(_address, HEX);                                               \
     if (_count) {                                                              \
       Serial.print(" count = ");                                               \

--- a/src/rp2040/Adafruit_FlashTransport_RP2040.cpp
+++ b/src/rp2040/Adafruit_FlashTransport_RP2040.cpp
@@ -79,7 +79,8 @@ Adafruit_FlashTransport_RP2040::Adafruit_FlashTransport_RP2040(
 void Adafruit_FlashTransport_RP2040::begin(void) {
   _flash_dev.total_size = _size;
 
-  // Read the RDID register to get the flash capacity.
+  #if 0
+  // Read the RDID register only for JEDEC ID
   uint8_t const cmd[] = {
       0x9f,
       0,
@@ -96,6 +97,13 @@ void Adafruit_FlashTransport_RP2040::begin(void) {
   _flash_dev.manufacturer_id = jedec_ids[0];
   _flash_dev.memory_type = jedec_ids[1];
   _flash_dev.capacity = jedec_ids[2];
+  #else
+  // skip JEDEC ID
+  _flash_dev.manufacturer_id = 0xad;
+  _flash_dev.memory_type = 0xaf;
+  _flash_dev.capacity = 0x00;
+  #endif
+
 }
 
 void Adafruit_FlashTransport_RP2040::end(void) {

--- a/src/rp2040/Adafruit_FlashTransport_RP2040.cpp
+++ b/src/rp2040/Adafruit_FlashTransport_RP2040.cpp
@@ -79,7 +79,7 @@ Adafruit_FlashTransport_RP2040::Adafruit_FlashTransport_RP2040(
 void Adafruit_FlashTransport_RP2040::begin(void) {
   _flash_dev.total_size = _size;
 
-  #if 0
+#if 0
   // Read the RDID register only for JEDEC ID
   uint8_t const cmd[] = {
       0x9f,
@@ -97,13 +97,12 @@ void Adafruit_FlashTransport_RP2040::begin(void) {
   _flash_dev.manufacturer_id = jedec_ids[0];
   _flash_dev.memory_type = jedec_ids[1];
   _flash_dev.capacity = jedec_ids[2];
-  #else
+#else
   // skip JEDEC ID
   _flash_dev.manufacturer_id = 0xad;
   _flash_dev.memory_type = 0xaf;
   _flash_dev.capacity = 0x00;
-  #endif
-
+#endif
 }
 
 void Adafruit_FlashTransport_RP2040::end(void) {


### PR DESCRIPTION
make flash.begin() "more compatible" with dvi by skipping reading jedec ID, which isn't too important for rp2040 port.

Also take chance to add pre-commit hook for clang and codespell.