### PR TITLE
nrf default PIN_QSPI_SCK, CS, IO0, IO1, IO2, IO3 to -1

### DIFF
--- a/src/qspi/Adafruit_FlashTransport_QSPI_NRF.cpp
+++ b/src/qspi/Adafruit_FlashTransport_QSPI_NRF.cpp
@@ -28,6 +28,32 @@
 #include "nrfx_qspi.h"
 #include <Arduino.h>
 
+// default PIN_QSPI_SCK, CS, IO0, IO1, IO2, IO3 to -1 to build with non-qpsi
+// board
+#ifndef PIN_QSPI_SCK
+#define PIN_QSPI_SCK -1
+#endif
+
+#ifndef PIN_QSPI_CS
+#define PIN_QSPI_CS -1
+#endif
+
+#ifndef PIN_QSPI_IO0
+#define PIN_QSPI_IO0 -1
+#endif
+
+#ifndef PIN_QSPI_IO1
+#define PIN_QSPI_IO1 -1
+#endif
+
+#ifndef PIN_QSPI_IO2
+#define PIN_QSPI_IO2 -1
+#endif
+
+#ifndef PIN_QSPI_IO3
+#define PIN_QSPI_IO3 -1
+#endif
+
 Adafruit_FlashTransport_QSPI::Adafruit_FlashTransport_QSPI(void)
     : Adafruit_FlashTransport_QSPI(PIN_QSPI_SCK, PIN_QSPI_CS, PIN_QSPI_IO0,
                                    PIN_QSPI_IO1, PIN_QSPI_IO2, PIN_QSPI_IO3) {}
@@ -91,8 +117,9 @@ void Adafruit_FlashTransport_QSPI::setClockSpeed(uint32_t clock_hz,
   // delay is set to one freq period
   uint8_t delay = 1;
 
-  if (clkdiv)
+  if (clkdiv) {
     delay = (1UL << (clkdiv - 1));
+  }
 
   NRF_QSPI->IFCONFIG1 &=
       ~(QSPI_IFCONFIG1_SCKFREQ_Msk | QSPI_IFCONFIG1_SCKDELAY_Msk);


### PR DESCRIPTION
nrf default PIN_QSPI_SCK, CS, IO0, IO1, IO2, IO3 to -1 to build with non-qpsi board. fix #141, superceded close #142