### PR TITLE
Fix typo in flash device definition

### DIFF
--- a/src/flash_devices.h
+++ b/src/flash_devices.h
@@ -533,7 +533,7 @@ typedef struct {
     .total_size = (1 << 21), /* 2 MiB */                                       \
         .start_up_time_us = 5000, .manufacturer_id = 0x85,                     \
     .memory_type = 0x60, .capacity = 0x15,                                     \
-    .max_clock_speed_mhz = 104.quad_enable_bit_mask = 0x02,                    \
+    .max_clock_speed_mhz = 104, .quad_enable_bit_mask = 0x02,                  \
     .has_sector_protection = false, .supports_fast_read = true,                \
     .supports_qspi = true, .supports_qspi_writes = true,                       \
     .write_status_register_split = false, .single_status_byte = false,         \

--- a/src/flash_devices.h
+++ b/src/flash_devices.h
@@ -529,7 +529,7 @@ typedef struct {
 // Datasheet:
 // https://www.puyasemi.com/uploadfiles/2021/12/202112201130233023.pdf
 #define P25Q16H                                                                \
-  {                                                                           \
+  {                                                                            \
     .total_size = (1 << 21), /* 2 MiB */                                       \
         .start_up_time_us = 5000, .manufacturer_id = 0x85,                     \
     .memory_type = 0x60, .capacity = 0x15, .max_clock_speed_mhz = 104,         \

--- a/src/flash_devices.h
+++ b/src/flash_devices.h
@@ -529,6 +529,7 @@ typedef struct {
 // Datasheet:
 // https://www.puyasemi.com/uploadfiles/2021/12/202112201130233023.pdf
 #define P25Q16H                                                                \
+  {                                                                           \
     .total_size = (1 << 21), /* 2 MiB */                                       \
         .start_up_time_us = 5000, .manufacturer_id = 0x85,                     \
     .memory_type = 0x60, .capacity = 0x15, .max_clock_speed_mhz = 104,         \

--- a/src/flash_devices.h
+++ b/src/flash_devices.h
@@ -529,6 +529,8 @@ typedef struct {
 // Datasheet:
 // https://www.puyasemi.com/uploadfiles/2021/12/202112201130233023.pdf
 #define P25Q16H                                                                \
+    .total_size = (1 << 21), /* 2 MiB */                                       \
+        .start_up_time_us = 5000, .manufacturer_id = 0x85,                     \
     .memory_type = 0x60, .capacity = 0x15, .max_clock_speed_mhz = 104,         \
     .quad_enable_bit_mask = 0x02, .has_sector_protection = false,              \
     .supports_fast_read = true, .supports_qspi = true,                         \

--- a/src/flash_devices.h
+++ b/src/flash_devices.h
@@ -529,15 +529,11 @@ typedef struct {
 // Datasheet:
 // https://www.puyasemi.com/uploadfiles/2021/12/202112201130233023.pdf
 #define P25Q16H                                                                \
-  {                                                                            \
-    .total_size = (1 << 21), /* 2 MiB */                                       \
-        .start_up_time_us = 5000, .manufacturer_id = 0x85,                     \
-    .memory_type = 0x60, .capacity = 0x15,                                     \
-    .max_clock_speed_mhz = 104, .quad_enable_bit_mask = 0x02,                  \
-    .has_sector_protection = false, .supports_fast_read = true,                \
-    .supports_qspi = true, .supports_qspi_writes = true,                       \
-    .write_status_register_split = false, .single_status_byte = false,         \
-    .is_fram = false,                                                          \
+    .memory_type = 0x60, .capacity = 0x15, .max_clock_speed_mhz = 104,         \
+    .quad_enable_bit_mask = 0x02, .has_sector_protection = false,              \
+    .supports_fast_read = true, .supports_qspi = true,                         \
+    .supports_qspi_writes = true, .write_status_register_split = false,        \
+    .single_status_byte = false, .is_fram = false,                             \
   }
 
 #endif // MICROPY_INCLUDED_ATMEL_SAMD_EXTERNAL_FLASH_DEVICES_H


### PR DESCRIPTION
This was a typo from a previous PR. This fixes the invalid struct.