### PR TITLE
add ESP32_EXT_FLASH and FLASH_NO_WREN build flags

### DIFF
--- a/src/Adafruit_SPIFlashBase.cpp
+++ b/src/Adafruit_SPIFlashBase.cpp
@@ -61,7 +61,7 @@ Adafruit_SPIFlashBase::Adafruit_SPIFlashBase(
   _ind_active = true;
 }
 
-#if defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_RP2040)
+#if !defined(ESP32_EXT_FLASH) && (defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_RP2040))
 
 // For ESP32 and RP2040 the SPI flash is already detected and configured
 // We could skip the initial sequence
@@ -323,7 +323,11 @@ void Adafruit_SPIFlashBase::waitUntilReady(void) {
   }
 
   // both WIP and WREN bit should be clear
+#if !defined(FLASH_NO_WREN)
   while (readStatus() & 0x03) {
+#else
+  while (readStatus() & 0x01) {
+#endif
     yield();
   }
 }

--- a/src/Adafruit_SPIFlashBase.cpp
+++ b/src/Adafruit_SPIFlashBase.cpp
@@ -61,7 +61,8 @@ Adafruit_SPIFlashBase::Adafruit_SPIFlashBase(
   _ind_active = true;
 }
 
-#if !defined(ESP32_EXT_FLASH) && (defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_RP2040))
+#if !defined(ESP32_EXT_FLASH) &&                                               \
+    (defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_RP2040))
 
 // For ESP32 and RP2040 the SPI flash is already detected and configured
 // We could skip the initial sequence


### PR DESCRIPTION
i'm using an external flash connected to an ESP32 so I need ESP32_EXT_FLASH
also, S25FL128SS25FL256S does not have WREN flag (WEL flag instead) so I need FLASH_NO_WREN flag

