### PR TITLE
Make Adafruit_FlashCache generic

### DIFF
--- a/src/Adafruit_FlashCache.cpp
+++ b/src/Adafruit_FlashCache.cpp
@@ -22,7 +22,8 @@
  * THE SOFTWARE.
  */
 
-#include "Adafruit_SPIFlash.h"
+#include "Adafruit_FlashCache.h"
+#include "Adafruit_SPIFlashBase.h"
 
 #if SPIFLASH_DEBUG
 #define SPICACHE_LOG(_new_addr)                                                \
@@ -49,7 +50,7 @@ static inline uint32_t offset_of(uint32_t addr) {
 
 Adafruit_FlashCache::Adafruit_FlashCache(void) { _addr = INVALID_ADDR; }
 
-bool Adafruit_FlashCache::sync(Adafruit_SPIFlash *fl) {
+bool Adafruit_FlashCache::sync(Adafruit_SPIFlashBase *fl) {
   if (_addr == INVALID_ADDR) {
     return true;
   }
@@ -62,7 +63,7 @@ bool Adafruit_FlashCache::sync(Adafruit_SPIFlash *fl) {
   return true;
 }
 
-bool Adafruit_FlashCache::write(Adafruit_SPIFlash *fl, uint32_t address,
+bool Adafruit_FlashCache::write(Adafruit_SPIFlashBase *fl, uint32_t address,
                                 void const *src, uint32_t len) {
   uint8_t const *src8 = (uint8_t const *)src;
   uint32_t remain = len;
@@ -96,7 +97,7 @@ bool Adafruit_FlashCache::write(Adafruit_SPIFlash *fl, uint32_t address,
   return true;
 }
 
-bool Adafruit_FlashCache::read(Adafruit_SPIFlash *fl, uint32_t address,
+bool Adafruit_FlashCache::read(Adafruit_SPIFlashBase *fl, uint32_t address,
                                uint8_t *buffer, uint32_t count) {
   // overwrite with cache value if available
   if ((_addr != INVALID_ADDR) &&

--- a/src/Adafruit_FlashCache.h
+++ b/src/Adafruit_FlashCache.h
@@ -42,7 +42,8 @@ public:
   bool sync(Adafruit_SPIFlashBase *fl);
   bool write(Adafruit_SPIFlashBase *fl, uint32_t dst, void const *src,
              uint32_t len);
-  bool read(Adafruit_SPIFlashBase *fl, uint32_t addr, uint8_t *dst, uint32_t count);
+  bool read(Adafruit_SPIFlashBase *fl, uint32_t addr, uint8_t *dst,
+            uint32_t count);
 };
 
 #endif /* ADAFRUIT_FLASHCACHE_H_ */

--- a/src/Adafruit_FlashCache.h
+++ b/src/Adafruit_FlashCache.h
@@ -29,7 +29,7 @@
 #include <stdint.h>
 
 // forward declaration
-class Adafruit_SPIFlash;
+class Adafruit_SPIFlashBase;
 
 class Adafruit_FlashCache {
 private:
@@ -39,10 +39,10 @@ private:
 public:
   Adafruit_FlashCache(void);
 
-  bool sync(Adafruit_SPIFlash *fl);
-  bool write(Adafruit_SPIFlash *fl, uint32_t dst, void const *src,
+  bool sync(Adafruit_SPIFlashBase *fl);
+  bool write(Adafruit_SPIFlashBase *fl, uint32_t dst, void const *src,
              uint32_t len);
-  bool read(Adafruit_SPIFlash *fl, uint32_t addr, uint8_t *dst, uint32_t count);
+  bool read(Adafruit_SPIFlashBase *fl, uint32_t addr, uint8_t *dst, uint32_t count);
 };
 
 #endif /* ADAFRUIT_FLASHCACHE_H_ */

--- a/src/Adafruit_SPIFlash.h
+++ b/src/Adafruit_SPIFlash.h
@@ -100,7 +100,7 @@ public:
     return writeSectors(block, src, nb);
   }
 
-private:
+protected:
   bool _cache_en;
   Adafruit_FlashCache *_cache;
 };


### PR DESCRIPTION
Changed Adafruit_FlashCache to operate on base class Adafruit_SPIFlashBase instead of derived Adafruit_SPIFlash so that it can be used with other derived classes inheriting from Adafruit_SPIFlashBase.
Changed private member variables in Adafruit_SPIFlash to protected to allow for external derived classes inheriting from Adafruit_SPIFlash as well.