### PR TITLE
Update Adafruit_FlashTransport_QSPI_SAMD.cpp

### DIFF
--- a/src/qspi/Adafruit_FlashTransport_QSPI_SAMD.cpp
+++ b/src/qspi/Adafruit_FlashTransport_QSPI_SAMD.cpp
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#ifdef __SAMD51__
+#if defined(__SAMD51__) && defined(EXTERNAL_FLASH_USE_QSPI)
 
 #include "Adafruit_FlashTransport.h"
 #include "wiring_private.h"


### PR DESCRIPTION
Support SAMD51 devices using flash connected to standard SPI instead of QSPI