### PR TITLE
correctly get jedec for pico

### DIFF
--- a/examples/flash_info/flash_info.ino
+++ b/examples/flash_info/flash_info.ino
@@ -73,14 +73,24 @@ void setup() {
   // Using a flash device not already listed? Start the flash memory by passing
   // it the array of device settings defined above, and the number of elements
   // in the array.
-
   // flash.begin(my_flash_devices, flashDevices);
 
+  uint32_t jedec_id = flash.getJEDECID();
   Serial.print("JEDEC ID: 0x");
-  Serial.println(flash.getJEDECID(), HEX);
-  Serial.print("Flash size: ");
+  Serial.println(jedec_id, HEX);
+  Serial.print("Flash size (usable): ");
   Serial.print(flash.size() / 1024);
   Serial.println(" KB");
+
+#ifdef ARDUINO_ARCH_RP2040
+  // For rp2 since flash device is also used for storing code, the flash.size()
+  // only return usable flash size for data which is dictated by e.g Menu->Flash
+  // Size -> 2MB (Sketch 1920KB, FS 64KB) --> size = 64KB For reference purpose,
+  // we only try to find and print actual flash device size using JEDEC here
+  Serial.print("Flash size (raw): ");
+  Serial.print(1 << ((jedec_id & 0xff) - 10));
+  Serial.println(" KB");
+#endif
 }
 
 void loop() {

--- a/src/rp2040/Adafruit_FlashTransport_RP2040.cpp
+++ b/src/rp2040/Adafruit_FlashTransport_RP2040.cpp
@@ -86,7 +86,6 @@ Adafruit_FlashTransport_RP2040::Adafruit_FlashTransport_RP2040(
 void Adafruit_FlashTransport_RP2040::begin(void) {
   _flash_dev.total_size = _size;
 
-#if 0
   // Read the RDID register only for JEDEC ID
   uint8_t const cmd[] = {
       0x9f,
@@ -96,7 +95,7 @@ void Adafruit_FlashTransport_RP2040::begin(void) {
   };
   uint8_t data[4];
   fl_lock(_idle_other_core_on_write);
-  flash_do_cmd(cmd, data, 5);
+  flash_do_cmd(cmd, data, 4);
   fl_unlock(_idle_other_core_on_write);
 
   uint8_t *jedec_ids = data + 1;
@@ -104,12 +103,6 @@ void Adafruit_FlashTransport_RP2040::begin(void) {
   _flash_dev.manufacturer_id = jedec_ids[0];
   _flash_dev.memory_type = jedec_ids[1];
   _flash_dev.capacity = jedec_ids[2];
-#else
-  // skip JEDEC ID
-  _flash_dev.manufacturer_id = 0xad;
-  _flash_dev.memory_type = 0xaf;
-  _flash_dev.capacity = 0x00;
-#endif
 }
 
 void Adafruit_FlashTransport_RP2040::end(void) {


### PR DESCRIPTION
correctly get jedec for pico also print out raw device size using jedec 3rd byte in flash_info.ino