### PR TITLE
Update to #include SdFat_Adafruit_Fork.h to avoid upstream clash

### DIFF
--- a/src/Adafruit_SPIFlash.h
+++ b/src/Adafruit_SPIFlash.h
@@ -29,7 +29,7 @@
 #include "Adafruit_SPIFlashBase.h"
 
 // implement SdFat Block Driver
-#include "SdFat.h"
+#include "SdFat_Adafruit_Fork.h"
 
 #if SD_FAT_VERSION >= 20000
 


### PR DESCRIPTION
This ties on with the changes to Adafruit SdFat fork to avoid clashing with upstream SdFat now present in the Pico Arduino community core.

Mental note to update examples too on monday