### PR TITLE
library.properties: Restrict SdFat to pre-2.3 versions.

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=SPI Flash filesystem support for FAT and CircuitPython FS support from
 category=Data Storage
 url=https://github.com/adafruit/Adafruit_SPIFlash
 architectures=*
-depends=Adafruit NeoPixel, SdFat - Adafruit Fork
+depends=Adafruit NeoPixel, SdFat - Adafruit Fork@2.2.54


### PR DESCRIPTION
As of https://github.com/adafruit/SdFat/pull/32 including https://github.com/adafruit/SdFat/commit/67e26476f15a3bae5f390d91b6cc01830920c55d into [adafruit/SdFat@2.3.50](https://github.com/adafruit/SdFat/tree/2.3.50), it's no longer possible to successfully build with this library for at least some platforms, using the latest release version of [SdFat - Adafruit Fork](https://github.com/adafruit/SdFat/).

It would probably be better to have a real fix to the underlying `override` error, by someone who knows and understands this library. For now, though, changing this library's dependency to specify [adafruit/SdFat@2.2.54](https://github.com/adafruit/SdFat/tree/2.2.54) resolves this issue and allows existing projects depending on adafruit/Adafruit_SPIFlash to still build.

```
Processing adafruit_feather_nrf52840 (platform: nordicnrf52; board: adafruit_feather_nrf52840; framework: arduino)
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Verbose mode can be enabled via `-v, --verbose` option
CONFIGURATION: https://docs.platformio.org/page/boards/nordicnrf52/adafruit_feather_nrf52840.html
PLATFORM: Nordic nRF52 (10.9.0) > Adafruit Feather nRF52840 Express
HARDWARE: NRF52840 64MHz, 243KB RAM, 796KB Flash
DEBUG: Current (custom) External (blackmagic, cmsis-dap, jlink, stlink)
PACKAGES:
 - framework-arduinoadafruitnrf52 @ 1.10601.0 (1.6.1)
 - framework-cmsis @ 2.50700.210515 (5.7.0)
 - tool-adafruit-nrfutil @ 1.503.0 (5.3)
 - tool-bossac-nordicnrf52 @ 1.10901.201022 (1.9.1)
 - tool-jlink @ 1.81206.0 (8.12.6)
 - tool-openocd @ 3.1200.0 (12.0)
 - tool-sreccat @ 1.164.0 (1.64)
 - toolchain-gccarmnoneeabi @ 1.70201.0 (7.2.1)
Converting Main.ino
LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
LDF Modes: Finder ~ chain, Compatibility ~ soft
Found 18 compatible libraries
Scanning dependencies...
Dependency Graph
|-- Adafruit NeoPixel @ 1.15.1
|-- MedianFilterLib2 @ 1.0.0
|-- Adafruit SleepyDog Library @ 1.6.5
|-- Adafruit SPIFlash @ 4.3.4
|-- Wire @ 1.0
|-- SdFat - Adafruit Fork @ 2.3.53
|-- Adafruit Little File System Libraries @ 0.11.0
|-- Adafruit TinyUSB Library
|-- Adafruit Bluefruit nRF52 Libraries
|-- Adafruit Internal File System on Bluefruit nRF52 @ 0.11.0
|-- SPI @ 1.0
Building in release mode
Compiling .pio\build\adafruit_feather_nrf52840\lib028\Adafruit_TinyUSB_Arduino\arduino\Adafruit_TinyUSB_API.cpp.o
Compiling .pio\build\adafruit_feather_nrf52840\lib028\Adafruit_TinyUSB_Arduino\arduino\Adafruit_USBD_CDC.cpp.o
Compiling .pio\build\adafruit_feather_nrf52840\lib028\Adafruit_TinyUSB_Arduino\arduino\Adafruit_USBD_Device.cpp.o
Compiling .pio\build\adafruit_feather_nrf52840\lib028\Adafruit_TinyUSB_Arduino\arduino\Adafruit_USBD_Interface.cpp.o
Compiling .pio\build\adafruit_feather_nrf52840\lib028\Adafruit_TinyUSB_Arduino\arduino\Adafruit_USBH_Host.cpp.o
Compiling .pio\build\adafruit_feather_nrf52840\lib028\Adafruit_TinyUSB_Arduino\arduino\cdc\Adafruit_USBH_CDC.cpp.o
Compiling .pio\build\adafruit_feather_nrf52840\lib028\Adafruit_TinyUSB_Arduino\arduino\hid\Adafruit_USBD_HID.cpp.o
Compiling .pio\build\adafruit_feather_nrf52840\lib028\Adafruit_TinyUSB_Arduino\arduino\midi\Adafruit_USBD_MIDI.cpp.o
Compiling .pio\build\adafruit_feather_nrf52840\lib028\Adafruit_TinyUSB_Arduino\arduino\msc\Adafruit_USBD_MSC.cpp.o
Compiling .pio\build\adafruit_feather_nrf52840\lib028\Adafruit_TinyUSB_Arduino\arduino\msc\Adafruit_USBH_MSC.cpp.o
Compiling .pio\build\adafruit_feather_nrf52840\lib028\Adafruit_TinyUSB_Arduino\arduino\ports\esp32\Adafruit_TinyUSB_esp32.cpp.o
Compiling .pio\build\adafruit_feather_nrf52840\lib028\Adafruit_TinyUSB_Arduino\arduino\ports\nrf\Adafruit_TinyUSB_nrf.cpp.o
Compiling .pio\build\adafruit_feather_nrf52840\lib028\Adafruit_TinyUSB_Arduino\arduino\ports\rp2040\Adafruit_TinyUSB_rp2040.cpp.o
Compiling .pio\build\adafruit_feather_nrf52840\lib028\Adafruit_TinyUSB_Arduino\arduino\ports\samd\Adafruit_TinyUSB_samd.cpp.o
Compiling .pio\build\adafruit_feather_nrf52840\lib028\Adafruit_TinyUSB_Arduino\arduino\video\Adafruit_USBD_Video.cpp.o
Compiling .pio\build\adafruit_feather_nrf52840\lib028\Adafruit_TinyUSB_Arduino\arduino\webusb\Adafruit_USBD_WebUSB.cpp.o
In file included from .pio\libdeps\adafruit_feather_nrf52840\SdFat - Adafruit Fork\src/ExFatLib/ExFatFile.h:882:0,
                 from .pio\libdeps\adafruit_feather_nrf52840\SdFat - Adafruit Fork\src/ExFatLib/ExFatVolume.h:27,
                 from .pio\libdeps\adafruit_feather_nrf52840\SdFat - Adafruit Fork\src/ExFatLib/ExFatLib.h:28,
                 from .pio\libdeps\adafruit_feather_nrf52840\SdFat - Adafruit Fork\src/SdFat.h:30,
                 from C:\Users\amansfield\.platformio\packages\framework-arduinoadafruitnrf52\libraries\Adafruit_TinyUSB_Arduino\src/arduino/msc/Adafruit_USBH_MSC.h:33,
                 from C:\Users\amansfield\.platformio\packages\framework-arduinoadafruitnrf52\libraries\Adafruit_TinyUSB_Arduino\src/Adafruit_TinyUSB.h:87,
                 from C:\Users\amansfield\.platformio\packages\framework-arduinoadafruitnrf52\libraries\Adafruit_TinyUSB_Arduino\src\arduino\Adafruit_TinyUSB_API.cpp:29:
.pio\libdeps\adafruit_feather_nrf52840\SdFat - Adafruit Fork\src/ExFatLib/../common/ArduinoFiles.h: In instantiation of 'class PrintFile<FatFile>':
.pio\libdeps\adafruit_feather_nrf52840\SdFat - Adafruit Fork\src/SdFat.h:468:23:   required from here
.pio\libdeps\adafruit_feather_nrf52840\SdFat - Adafruit Fork\src/ExFatLib/../common/ArduinoFiles.h:52:8: error: 'void PrintFile<BaseFile>::flush() [with BaseFile = FatFile]' marked 'override', but does not override
   void flush() override { BaseFile::sync(); }
        ^~~~~
Compiling .pio\build\adafruit_feather_nrf52840\lib028\Adafruit_TinyUSB_Arduino\class\audio\audio_device.c.o
*** [.pio\build\adafruit_feather_nrf52840\lib028\Adafruit_TinyUSB_Arduino\arduino\Adafruit_TinyUSB_API.cpp.o] Error 1
In file included from .pio\libdeps\adafruit_feather_nrf52840\SdFat - Adafruit Fork\src/ExFatLib/ExFatFile.h:882:0,
                 from .pio\libdeps\adafruit_feather_nrf52840\SdFat - Adafruit Fork\src/ExFatLib/ExFatVolume.h:27,
                 from .pio\libdeps\adafruit_feather_nrf52840\SdFat - Adafruit Fork\src/ExFatLib/ExFatLib.h:28,
                 from .pio\libdeps\adafruit_feather_nrf52840\SdFat - Adafruit Fork\src/SdFat.h:30,
                 from C:\Users\amansfield\.platformio\packages\framework-arduinoadafruitnrf52\libraries\Adafruit_TinyUSB_Arduino\src\arduino\msc\Adafruit_USBH_MSC.h:33,
                 from C:\Users\amansfield\.platformio\packages\framework-arduinoadafruitnrf52\libraries\Adafruit_TinyUSB_Arduino\src\arduino\msc\Adafruit_USBH_MSC.cpp:34:
.pio\libdeps\adafruit_feather_nrf52840\SdFat - Adafruit Fork\src/ExFatLib/../common/ArduinoFiles.h: In instantiation of 'class PrintFile<FatFile>':
.pio\libdeps\adafruit_feather_nrf52840\SdFat - Adafruit Fork\src/SdFat.h:468:23:   required from here
.pio\libdeps\adafruit_feather_nrf52840\SdFat - Adafruit Fork\src/ExFatLib/../common/ArduinoFiles.h:52:8: error: 'void PrintFile<BaseFile>::flush() [with BaseFile = FatFile]' marked 'override', but does not override
   void flush() override { BaseFile::sync(); }
        ^~~~~
*** [.pio\build\adafruit_feather_nrf52840\lib028\Adafruit_TinyUSB_Arduino\arduino\msc\Adafruit_USBH_MSC.cpp.o] Error 1
====================================================================================================================================== [FAILED] Took 6.42 seconds ======================================================================================================================================

 *  The terminal process "C:\Users\amansfield\.platformio\penv\Scripts\platformio.exe 'run', '--target', 'upload', '--target', 'monitor', '--environment', 'adafruit_feather_nrf52840'" terminated with exit code: 1. 
```